### PR TITLE
Bl 841 reindex skip supressed

### DIFF
--- a/almaoai_harvest.py
+++ b/almaoai_harvest.py
@@ -45,7 +45,7 @@ def almaoai_harvest(ds, **kwargs):
         sickle = Sickle(endpoint_url)
         try:
             records = sickle.ListRecords(**{'metadataPrefix': 'marc21', 'set': 'blacklight', 'from': '{}'.format(date)})
-        except :
+        except:
             print("No records matched the date range given")
             records = []
 

--- a/almaoai_harvest.py
+++ b/almaoai_harvest.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 from sickle import Sickle
+from sickle.oaiexceptions import NoRecordsMatch
 from airflow.models import Variable
 from airflow import AirflowException
 import xml.etree.ElementTree
@@ -42,7 +43,12 @@ def almaoai_harvest(ds, **kwargs):
         deletedfile = open(deletedfilename, 'w')
 
         sickle = Sickle(endpoint_url)
-        records = sickle.ListRecords(**{'metadataPrefix': 'marc21', 'set': 'blacklight', 'from': '{}'.format(date)})
+        try:
+            records = sickle.ListRecords(**{'metadataPrefix': 'marc21', 'set': 'blacklight', 'from': '{}'.format(date)})
+        except :
+            print("No records matched the date range given")
+            records = []
+
         # xml.etree.ElementTree.register_namespace('xmlns','http://www.loc.gov/MARC21/slim')
         newfirstline = '<?xml version="1.0" encoding="UTF-8"?>'
         newroot = '<collection xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">'
@@ -64,10 +70,10 @@ def almaoai_harvest(ds, **kwargs):
                 # else:
                 subrecord.insert(0, header)
                 #outfile.write(xml.dom.minidom.parseString(xml.etree.ElementTree.tostring(subrecord,'unicode')).toprettyxml(indent="\t"))
-                outfile.write(xml.etree.ElementTree.tostring(subrecord, encoding='unicode'))
+                outfile.write('{}\n'.format(xml.etree.ElementTree.tostring(subrecord, encoding='unicode')))
                 num_updated_recs += 1
             elif header.get('status') == 'deleted':
-                deletedfile.write('<record>{}</record>'.format(xml.etree.ElementTree.tostring(header, encoding='unicode')))
+                deletedfile.write('<record>{}</record>\n'.format(xml.etree.ElementTree.tostring(header, encoding='unicode')))
                 num_deleted_recs += 1
             else:
                 print('subrecord issue?')
@@ -82,12 +88,16 @@ def almaoai_harvest(ds, **kwargs):
         Variable.set("almaoai_last_num_oai_delete_recs", num_deleted_recs)
         Variable.set("almaoai_last_harvest_date", date_current_harvest)
     except Exception as e:
-        if outfile is not None and outfile.closed is not True:
-            outfile.close()
-        if deletedfile is not None and deletedfile.closed is not True:
-            deletedfile.close()
+        print(str(e))
+        if outfile is not None:
+            if outfile.closed is not True:
+                outfile.close()
+            os.remove(outfile) #if we died in the middle of a harvest, don't keep a partial download
+        if deletedfile is not None:
+            if deletedfile.closed is not True:
+                deletedfile.close()
+            os.remove(deletedfile)
         if r is not None:
             print(r.raw)
-        print(e.message)
 
         raise AirflowException('Harvest failed.')

--- a/almasftp_fetch.py
+++ b/almasftp_fetch.py
@@ -33,7 +33,7 @@ def almasftp_fetch():
         x = p.expect(['Permission denied', 'sftp>'])
         if not x:
             print('Permission denied for password:')
-            print(password)
+            print(passwd)
             p.kill(0)
         else:
             x = p.sendline('cd ' + remotepath)
@@ -43,7 +43,7 @@ def almasftp_fetch():
             x = p.sendline('mget ' + file_prefix + '*' + file_extension)
             x = p.expect('sftp>', timeout=360)
             x = p.isalive()
-            x = p.close()
+            p.close()
             retval = p.exitstatus
     except EOF:
         print(str(p))
@@ -54,4 +54,4 @@ def almasftp_fetch():
         print('Transfer failed: TIMEOUT.')
         raise AirflowException('Transfer failed: TIMEOUT.')
     except Exception as e:
-        raise AirflowException('Transfer failed: {}.'.format(e.message))
+        raise AirflowException('Transfer failed: {}.'.format(str(e)))

--- a/almasftp_fetch.py
+++ b/almasftp_fetch.py
@@ -41,7 +41,7 @@ def almasftp_fetch():
             x = p.sendline('lcd ' + localpath)
             x = p.expect('sftp>')
             x = p.sendline('mget ' + file_prefix + '*' + file_extension)
-            x = p.expect('sftp>')
+            x = p.expect('sftp>', timeout=360)
             x = p.isalive()
             x = p.close()
             retval = p.exitstatus

--- a/processtrajectlog.py
+++ b/processtrajectlog.py
@@ -25,13 +25,13 @@ def process_trajectlog(ds, **kwargs):
                 if line.find(errstr) > 0:
                     m = re.search(r"Solr error response: (.*): {", line)
                     if m is not None:
-                       solr_return_code = m.group(1)
-                       num_solr_errors += 1
-                       if solr_return_code != '409':
-                           num_severe_errors += 1
-                       m = re.search(r"source_id:(.*) output_id:(.*)>:", line)
-                       if m is not None:
-                           print("Skipping ID: {}".format(m.group(1)))
+                        solr_return_code = m.group(1)
+                        num_solr_errors += 1
+                        if solr_return_code != '409':
+                            num_severe_errors += 1
+                        m = re.search(r"source_id:(.*) output_id:(.*)>:", line)
+                        if m is not None:
+                            print("Skipping ID: {}".format(m.group(1)))
                 elif line.find(skipstr) > 0:
                     m = re.search(r"ERROR Traject::Indexer#process returning 'false' due to (.*) skipped records.", line)
                     if m is not None:
@@ -53,4 +53,4 @@ def process_trajectlog(ds, **kwargs):
             print("Num skipped: {}".format(num_skipped))
             Variable.set("traject_num_rejected", num_solr_errors)
         except Exception as e:
-            print('Error parsing log {} bailing {}.'.format(trajectlog_fname, e.message))
+            print('Error parsing log {} bailing {}.'.format(trajectlog_fname, str(e)))

--- a/processtrajectlog.py
+++ b/processtrajectlog.py
@@ -11,18 +11,32 @@ import re
 def process_trajectlog(ds, **kwargs):
     num_skipped = 0
     num_ingested = 0
+    num_solr_errors = 0
+    num_severe_errors = 0
     skipstr = "ERROR Traject::Indexer#process returning 'false' due to "
+    batcherrstr = "Error in Solr batch add. Will retry documents individually at performance penalty"
+    errstr = "Could not add record"
     finishstr = "INFO finished Traject::Indexer#process: "
-    trajectlog_fname = Variable.get("AIRFLOW_DATA_DIR") + '/traject_log.tmp'
+    trajectlog_fname = '{}/traject_log_{}.tmp'.format(Variable.get("AIRFLOW_DATA_DIR"), kwargs['marcfilename'])
+    print('Parsing {}'.format(trajectlog_fname))
     with open(trajectlog_fname) as fd:
         try:
             for line in fd:
-                if line.find(skipstr) > 0:
+                if line.find(errstr) > 0:
+                    m = re.search(r"Solr error response: (.*): {", line)
+                    if m is not None:
+                       solr_return_code = m.group(1)
+                       num_solr_errors += 1
+                       if solr_return_code != '409':
+                           num_severe_errors += 1
+                       m = re.search(r"source_id:(.*) output_id:(.*)>:", line)
+                       if m is not None:
+                           print("Skipping ID: {}".format(m.group(1)))
+                elif line.find(skipstr) > 0:
                     m = re.search(r"ERROR Traject::Indexer#process returning 'false' due to (.*) skipped records.", line)
                     if m is not None:
                         num_skipped = m.group(1)
-                        print(num_skipped)
-                        Variable.set("traject_num_rejected", num_skipped)
+                        #Variable.set("traject_num_rejected", num_skipped)
                     else:
                         print(line)
                 # this is redundant with the info from the oaiharvest
@@ -33,6 +47,10 @@ def process_trajectlog(ds, **kwargs):
                 #         print(num_ingested)
                 #     else:
                 #         print( line )
-            os.remove(trajectlog_fname) #contents are also in the ingest_marc task so we don't need this anymore
+            #os.remove(trajectlog_fname) #contents are also in the ingest_marc task so we don't need this anymore
+            print("Num severe errors: {}".format(num_severe_errors))
+            print("Num solr errors: {}".format(num_solr_errors))
+            print("Num skipped: {}".format(num_skipped))
+            Variable.set("traject_num_rejected", num_solr_errors)
         except Exception as e:
             print('Error parsing log {} bailing {}.'.format(trajectlog_fname, e.message))

--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -9,9 +9,15 @@ elif [[ -s "/usr/local/rvm/scripts/rvm" ]] ; then
 else
   printf "ERROR: An RVM installation was not found.\n"
 fi
+
+if [ ! -e ${1} ]
+then
+  exit 1
+fi
+
 cd $HOME/tul_cob
 rvm use 2.4.1@tul_cob
 gem install bundler
 bundle install
-bundle exec traject -c lib/traject/indexer_config.rb ${1}
+SOLR_URL='http://162.216.18.86:8983/solr/blacklight-core' bundle exec traject -c lib/traject/indexer_config.rb ${1}
 return 0

--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -19,5 +19,5 @@ cd $HOME/tul_cob
 rvm use 2.4.1@tul_cob
 gem install bundler
 bundle install
-SOLR_URL='http://162.216.18.86:8983/solr/blacklight-core' bundle exec traject -c lib/traject/indexer_config.rb ${1}
+SOLR_URL="$2" bundle exec traject -c lib/traject/indexer_config.rb ${1}
 return 0

--- a/scripts/ingest_marc_multi.sh
+++ b/scripts/ingest_marc_multi.sh
@@ -15,6 +15,6 @@ gem install bundler
 bundle install
 for f in $1/alma_bibs__*.xml
 do
-TRAJECT_FULL_REINDEX='yes' SOLR_URL='http://162.216.18.86:8983/solr/blacklight-core' bundle exec traject -c lib/traject/indexer_config.rb $f
+TRAJECT_FULL_REINDEX='yes' SOLR_URL="$2" bundle exec traject -c lib/traject/indexer_config.rb $f
 done
 return 0

--- a/scripts/ingest_marc_multi.sh
+++ b/scripts/ingest_marc_multi.sh
@@ -15,6 +15,6 @@ gem install bundler
 bundle install
 for f in $1/alma_bibs__*.xml
 do
-bundle exec traject -c lib/traject/indexer_config.rb $f
+TRAJECT_FULL_REINDEX='yes' SOLR_URL='http://162.216.18.86:8983/solr/blacklight-core' bundle exec traject -c lib/traject/indexer_config.rb $f
 done
 return 0

--- a/task_ingestmarc.py
+++ b/task_ingestmarc.py
@@ -16,5 +16,5 @@ def ingest_marc(dag, marcfilename, taskid):
         )
 
     else:
-        raise Exception(str(os.path.isfile(ingest_command)) + " Cannot locate {}".format(ingest_command))
+        raise Exception("Cannot locate {}".format(ingest_command))
     return t1

--- a/task_ingestmarc.py
+++ b/task_ingestmarc.py
@@ -2,16 +2,20 @@ from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.models import Variable
 from airflow import AirflowException
+from airflow.hooks.base_hook import BaseHook
 import os
 
 
 def ingest_marc(dag, marcfilename, taskid):
+    # http://162.216.18.86:8983/solr/blacklight-core
+    conn = BaseHook.get_connection('AIRFLOW_CONN_SOLR_LEADER')
+    solr_endpoint = 'http://' + conn.host + ':' + str(conn.port) + '/solr/' + Variable.get('BLACKLIGHT_CORE_NAME')
     infilename = Variable.get("AIRFLOW_DATA_DIR") + '/' + marcfilename
     ingest_command = Variable.get("AIRFLOW_HOME") + "/dags/cob_datapipeline/scripts/ingest_marc.sh"
     if os.path.isfile(ingest_command):
         t1 = BashOperator(
             task_id=taskid,
-            bash_command="source {} {}  2>&1  | tee {}/traject_log_{}.tmp ".format(ingest_command, infilename, Variable.get("AIRFLOW_DATA_DIR"), marcfilename) + ' ',
+            bash_command="source {} {} {}  2>&1  | tee {}/traject_log_{}.tmp ".format(ingest_command, infilename, solr_endpoint, Variable.get("AIRFLOW_DATA_DIR"), marcfilename) + ' ',
             dag=dag
         )
 

--- a/task_ingestsftpmarc.py
+++ b/task_ingestsftpmarc.py
@@ -2,16 +2,20 @@ from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.models import Variable
 from airflow import AirflowException
+from airflow.hooks.base_hook import BaseHook
 import os
 
 
 def ingest_sftpmarc(dag):
+    # http://162.216.18.86:8983/solr/blacklight-core
+    conn = BaseHook.get_connection('AIRFLOW_CONN_SOLR_LEADER')
+    solr_endpoint = 'http://' + conn.host + ':' + str(conn.port) + '/solr/' + Variable.get('BLACKLIGHT_CORE_NAME')  
     ingest_command = Variable.get("AIRFLOW_HOME") + "/dags/cob_datapipeline/scripts/ingest_marc_multi.sh"
     marcfilepath = Variable.get("AIRFLOW_DATA_DIR") + "/sftpdump/"
     if os.path.isfile(ingest_command):
         t1 = BashOperator(
             task_id='ingest_sftp_marc',
-            bash_command="source {} {}  2>&1  | tee {}/traject_log.tmp ".format(ingest_command, marcfilepath, Variable.get("AIRFLOW_DATA_DIR")) + ' ',
+            bash_command="source {} {} {}  2>&1  | tee {}/traject_log.tmp ".format(ingest_command, marcfilepath, solr_endpoint, Variable.get("AIRFLOW_DATA_DIR")) + ' ',
             dag=dag
         )
 

--- a/tul_cob_fullreindex_dag.py
+++ b/tul_cob_fullreindex_dag.py
@@ -47,7 +47,7 @@ get_num_solr_docs_pre = task_solrgetnumdocs(dag, core_name, 'get_num_solr_docs_p
 get_num_solr_docs_post = task_solrgetnumdocs(dag, core_name, 'get_num_solr_docs_post')
 
 ingestsftpmarc_task = ingest_sftpmarc(dag)
-ingest_marc_boundwith = ingest_marc(dag, '/boundwith_merged.xml', 'ingest_boundwith_merged')
+ingest_marc_boundwith = ingest_marc(dag, 'boundwith_merged.xml', 'ingest_boundwith_merged')
 
 
 parse_sftpdump = PythonOperator(

--- a/tul_cob_pipeline_dag.py
+++ b/tul_cob_pipeline_dag.py
@@ -33,8 +33,8 @@ default_args = {
 dag = DAG(
     'tul_cob', default_args=default_args, catchup=False, schedule_interval=timedelta(hours=6))
 
-
-ingest_marc = ingest_marc(dag, 'oairecords.xml', 'ingest_marc')
+marcfilename = 'oairecords.xml'
+ingest_marc = ingest_marc(dag, marcfilename, 'ingest_marc')
 
 pause_replication = task_solr_replication(dag, core_name, "disable")
 resume_replication = task_solr_replication(dag, core_name, "enable")
@@ -71,7 +71,7 @@ rename_marc = PythonOperator(
 parse_traject = PythonOperator(
     task_id='process_trajectlog',
     python_callable=process_trajectlog,
-    op_kwargs={},
+    op_kwargs={'marcfilename': marcfilename},
     dag=dag
 )
 


### PR DESCRIPTION
pushing things towards production
linting
parameterized solr URL for ingest
better error handling processing traject log
break oai xml into single lines
oai pmh more robust error handling 
always set  traject skipped count even if there were none
traject skipstr count is different than the individual error messages, so count those instead
traject logging
don’t try to ingest a nonexistent marcfile
better tracking of what marcfile we’re working with e.g. when moving old files