### PR TITLE
Do not bundle install cob production group.

### DIFF
--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -12,6 +12,6 @@ fi
 cd $HOME/tul_cob
 rvm use 2.4.1@tul_cob
 gem install bundler
-bundle install
+bundle install --without production
 bundle exec traject -c lib/traject/indexer_config.rb ${1}
 return 0

--- a/scripts/ingest_marc_multi.sh
+++ b/scripts/ingest_marc_multi.sh
@@ -12,7 +12,7 @@ fi
 cd $HOME/tul_cob
 rvm use 2.4.1@tul_cob
 gem install bundler
-bundle install
+bundle install --without production
 for f in $1/alma_bibs__*.xml
 do
 bundle exec traject -c lib/traject/indexer_config.rb $f


### PR DESCRIPTION
The production group includes mysql which needs to be installed or
compiled.  This will not be required once we separate traject tasks from
tul_cob.