### PR TITLE
Date clobber on OAI ingest (temporary until date issues are sorted out)

### DIFF
--- a/almaoai_harvest.py
+++ b/almaoai_harvest.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta
 import time
 from sickle import Sickle
 from sickle.oaiexceptions import NoRecordsMatch
@@ -14,23 +14,21 @@ def almaoai_harvest(ds, **kwargs):
         outfile = None
         deletedfile = None
         r = None
-        # At some point support for HHMMSS granularity was added to the alma endpoint
-        # This can be verified at https://temple.alma.exlibrisgroup.com/view/oai/01TULI_INST/request?verb=Identify
-        UTC_DATESTAMP_FSTR = '%Y-%m-%dT%H:%M:%SZ'
-        data_dir = Variable.get("AIRFLOW_DATA_DIR")
-        endpoint_url = Variable.get("ALMA_OAI_ENDPOINT") + "/request" #'https://temple.alma.exlibrisgroup.com/view/oai/01TULI_INST/request'
-        date_current_harvest = datetime.datetime.now().strftime(UTC_DATESTAMP_FSTR)
         num_deleted_recs = 0
         num_updated_recs = 0
-        # note: OAI date ranges are inclusive on both ends
+        # At some point support for HHMMSS granularity was added to the alma endpoint
+        # This can be verified at https://temple.alma.exlibrisgroup.com/view/oai/01TULI_INST/request?verb=Identify
+        # NOTE: OAI date ranges are inclusive on both ends
+        UTC_DATESTAMP_FSTR = '%Y-%m-%dT%H:%M:%SZ'
+        data_dir = Variable.get("AIRFLOW_DATA_DIR")
+        endpoint_url = Variable.get("ALMA_OAI_ENDPOINT") + "/request"
+        # e.g. 'https://temple.alma.exlibrisgroup.com/view/oai/01TULI_INST/request'
+        oai_publish_interval = Variable.get("ALMA_OAI_PUBLISH_INTERVAL")
 
-        try:
-            date = Variable.get("almaoai_last_harvest_date")
-        except KeyError:
-            Variable.set("almaoai_last_harvest_date", date_current_harvest)
-            date = date_current_harvest
-
-        print("Harvesting starting from {}".format(date))
+        date_current_harvest = datetime.now()
+        date_last_harvest = datetime.strptime(Variable.get("almaoai_last_harvest_date"), UTC_DATESTAMP_FSTR)
+        harvest_from_date = (date_last_harvest - timedelta(hours=int(oai_publish_interval))).strftime(UTC_DATESTAMP_FSTR)
+        harvest_until_date = date_current_harvest.strftime(UTC_DATESTAMP_FSTR)
 
         outfilename = data_dir + '/oairecords.xml'
         if os.path.isfile(outfilename):
@@ -43,8 +41,15 @@ def almaoai_harvest(ds, **kwargs):
         deletedfile = open(deletedfilename, 'w')
 
         sickle = Sickle(endpoint_url)
+        harvest_args = {
+            'metadataPrefix': 'marc21',
+            'set': 'blacklight',
+            'from': '{}'.format(harvest_from_date),
+            'until': '{}'.format(harvest_until_date)
+        }
+        print("Harvesting {}".format(harvest_args))
         try:
-            records = sickle.ListRecords(**{'metadataPrefix': 'marc21', 'set': 'blacklight', 'from': '{}'.format(date)})
+            records = sickle.ListRecords(**harvest_args)
         except:
             print("No records matched the date range given")
             records = []
@@ -86,17 +91,24 @@ def almaoai_harvest(ds, **kwargs):
         Variable.set("almaoai_last_num_oai_update_recs", num_updated_recs)
         print("num_deleted_recs {}".format(num_deleted_recs))
         Variable.set("almaoai_last_num_oai_delete_recs", num_deleted_recs)
-        Variable.set("almaoai_last_harvest_date", date_current_harvest)
+        # If we got nothing, it might be because the OAI publish interval
+        # changed on us. Don't update harvest date because we should come back
+        # to this same time again in hopes the OAI endpoint got new data for
+        # this time interval
+        if num_updated_recs == 0:
+            print("Got no OAI records, we'll revisit this date next harvest.")
+        else:
+            Variable.set("almaoai_last_harvest_date", date_current_harvest)
     except Exception as e:
         print(str(e))
         if outfile is not None:
             if outfile.closed is not True:
                 outfile.close()
-            os.remove(outfile) #if we died in the middle of a harvest, don't keep a partial download
+            os.remove(outfilename) #if we died in the middle of a harvest, don't keep a partial download
         if deletedfile is not None:
             if deletedfile.closed is not True:
                 deletedfile.close()
-            os.remove(deletedfile)
+            os.remove(deletedfilename)
         if r is not None:
             print(r.raw)
 

--- a/almasftp_fetch.py
+++ b/almasftp_fetch.py
@@ -4,6 +4,7 @@ from pexpect import *
 import sys
 import os
 
+
 def almasftp_fetch():
     host = Variable.get('ALMASFTP_HOST')
     port = Variable.get('ALMASFTP_PORT')

--- a/processtrajectlog.py
+++ b/processtrajectlog.py
@@ -1,5 +1,6 @@
 from airflow.models import Variable
 from airflow import AirflowException
+import time
 import os
 import re
 
@@ -39,18 +40,12 @@ def process_trajectlog(ds, **kwargs):
                         #Variable.set("traject_num_rejected", num_skipped)
                     else:
                         print(line)
-                # this is redundant with the info from the oaiharvest
-                # elif line.find(finishstr) > 0:
-                #     m = re.search(r'INFO finished Traject::Indexer#process: (.*)', line)
-                #     if m != None:
-                #         num_ingested = m.group(1)
-                #         print(num_ingested)
-                #     else:
-                #         print( line )
-            #os.remove(trajectlog_fname) #contents are also in the ingest_marc task so we don't need this anymore
-            print("Num severe errors: {}".format(num_severe_errors))
-            print("Num solr errors: {}".format(num_solr_errors))
-            print("Num skipped: {}".format(num_skipped))
-            Variable.set("traject_num_rejected", num_solr_errors)
         except Exception as e:
             print('Error parsing log {} bailing {}.'.format(trajectlog_fname, str(e)))
+
+    print("Num severe errors: {}".format(num_severe_errors))
+    print("Num solr errors: {}".format(num_solr_errors))
+    print("Num skipped: {}".format(num_skipped))
+    Variable.set("traject_num_rejected", num_solr_errors)
+    if os.path.isfile(trajectlog_fname):
+        os.rename(trajectlog_fname, '{}-{}.log'.format(trajectlog_fname, time.time()))

--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -16,5 +16,5 @@ fi
 cd $HOME/tul_cob
 gem install bundler
 bundle install
-SOLR_URL="$2" bundle exec traject -c lib/traject/indexer_config.rb ${1}
+SOLR_DISABLE_UPDATE_DATE_CHECK=yes SOLR_URL="$2" bundle exec traject -c lib/traject/indexer_config.rb ${1}
 return 0

--- a/task_ingestmarc.py
+++ b/task_ingestmarc.py
@@ -12,9 +12,10 @@ def ingest_marc(dag, marcfilename, taskid):
     solr_endpoint = 'http://' + conn.host + ':' + str(conn.port) + '/solr/' + Variable.get('BLACKLIGHT_CORE_NAME')
     infilename = Variable.get("AIRFLOW_DATA_DIR") + '/' + marcfilename
     ingest_command = Variable.get("AIRFLOW_HOME") + "/dags/cob_datapipeline/scripts/ingest_marc.sh"
-    logfile = "{}/traject_log_{}.log".format(Variable.get("AIRFLOW_LOG_DIR"), marcfilename) 
+    logfile = "{}/traject_log_{}.log".format(Variable.get("AIRFLOW_LOG_DIR"), marcfilename)
     if not os.path.exists(logfile):
-        with open(logfile, 'w'): pass
+        with open(logfile, 'w'):
+            pass
 
     if os.path.isfile(ingest_command):
         t1 = BashOperator(

--- a/task_ingestsftpmarc.py
+++ b/task_ingestsftpmarc.py
@@ -9,12 +9,13 @@ import os
 def ingest_sftpmarc(dag):
     # http://162.216.18.86:8983/solr/blacklight-core
     conn = BaseHook.get_connection('AIRFLOW_CONN_SOLR_LEADER')
-    solr_endpoint = 'http://' + conn.host + ':' + str(conn.port) + '/solr/' + Variable.get('BLACKLIGHT_CORE_NAME')  
+    solr_endpoint = 'http://' + conn.host + ':' + str(conn.port) + '/solr/' + Variable.get('BLACKLIGHT_CORE_NAME')
     ingest_command = Variable.get("AIRFLOW_HOME") + "/dags/cob_datapipeline/scripts/ingest_marc_multi.sh"
     marcfilepath = Variable.get("AIRFLOW_DATA_DIR") + "/sftpdump/"
     logfile = "{}/traject_log_{}.log".format(Variable.get("AIRFLOW_LOG_DIR"), "sftp")
     if not os.path.exists(logfile):
-        with open(logfile, 'w'): pass
+        with open(logfile, 'w'):
+            pass
 
     if os.path.isfile(ingest_command):
         t1 = BashOperator(

--- a/tul_cob_fullreindex_dag.py
+++ b/tul_cob_fullreindex_dag.py
@@ -32,7 +32,9 @@ default_args = {
 }
 
 dag = DAG(
-    'tul_cob_reindex', default_args=default_args, catchup=False, schedule_interval=None)
+    'tul_cob_reindex', default_args=default_args, catchup=False,
+    max_active_runs=1, schedule_interval=None
+)
 
 
 almasftp_task = task_almasftp(dag)


### PR DESCRIPTION
Create variable for OAI publishing interval
Set OAI “from” date to account for the OAI publishing interval
Set explicit OAI “until” date
Don’t move forward harvest date until we actually retrieve records
Move traject log once we’ve read it so that we don’t re-read it again
Add comments to dag file
Make sure key vars are set on startup
Set max_active_runs so that we only have one dag run at a time
os.remove works on paths, not file objects (obvs)
General pep8 linting