### PR TITLE
Updated start_date

### DIFF
--- a/tul_cob_pipeline_dag.py
+++ b/tul_cob_pipeline_dag.py
@@ -39,7 +39,7 @@ except KeyError:
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime(2018, 12, 13),
+    'start_date': datetime(2018, 12, 13, 03),
     'email': ['tug76662@temple.edu'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/tul_cob_pipeline_dag.py
+++ b/tul_cob_pipeline_dag.py
@@ -39,7 +39,7 @@ except KeyError:
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime(2018, 12, 13, 03),
+    'start_date': datetime(2018, 12, 13, 3),
     'email': ['tug76662@temple.edu'],
     'email_on_failure': False,
     'email_on_retry': False,


### PR DESCRIPTION
- The Airflow tul_cob schedule needs be as follows, using UTC: 3:00, 
9:00, 15:00, 21:00.
- This update is based on the assumption that timezone should be UTC for cob_datapipeline. This can be edited to EST if needed. 
- Note from Christina: not merge into QA until variables pr is up too