### PR TITLE
Refactor parsesftpdump to move old dumps. Added step to DAG. 

### DIFF
--- a/almasftp_fetch.py
+++ b/almasftp_fetch.py
@@ -39,7 +39,7 @@ def almasftp_fetch():
             x = p.sendline('lcd ' + localpath)
             x = p.expect('sftp>')
             x = p.sendline('mget ' + file_prefix + '*' + file_extension)
-            x = p.expect('sftp>', timeout=360)
+            x = p.expect('sftp>', timeout=720)
             x = p.isalive()
             p.close()
             retval = p.exitstatus

--- a/parsesftpdump.py
+++ b/parsesftpdump.py
@@ -7,30 +7,65 @@ import time
 import re
 from airflow.models import Variable
 
-def parse_sftpdump(ds, **kwargs):
-    UTC_DATESTAMP_FSTR = '%Y-%m-%dT%H:%M:%SZ'
-    marcfile_prefix = 'alma_bibs__'
-    marcfile_extension = 'xml'
-    ingest_command = Variable.get("AIRFLOW_HOME") + "/dags/cob_datapipeline/scripts/ingest_marc_multi.sh"
-    marcfilepath = Variable.get("AIRFLOW_DATA_DIR") + "/sftpdump/"
+UTC_DATESTAMP_FSTR = '%Y-%m-%dT%H:%M:%SZ'
+MARCFILE_PREFIX = 'alma_bibs__'
+MARCFILE_EXTENSION = 'xml'
+ingest_command = Variable.get("AIRFLOW_HOME") + "/dags/cob_datapipeline/scripts/ingest_marc_multi.sh"
+marcfilepath = Variable.get("AIRFLOW_DATA_DIR") + "/sftpdump/"
+
+# parse filename for datestamp
+# e.g. alma_bibs__2018041306_6863237930003811_new_61.xml
+def get_dump_date(marcdircontents):
+    datestamp = None
+    datestampregex = re.compile(r"alma_bibs__(.*)_(.*).xml")
+    marcfileregex = re.compile(MARCFILE_PREFIX + r".*\." + MARCFILE_EXTENSION + "$")
+    for infilename in marcdircontents:
+        if marcfileregex.search(infilename):
+            rxresults = datestampregex.search(infilename)
+            if rxresults is not None:
+                datestamp = rxresults.group(1)
+                break
+    return datestamp
+
+def parse_sftpdump_dates(ds, **kwargs):
     date = None
     if os.path.isfile(ingest_command):
         marcdircontents = os.listdir(marcfilepath)
-        marcfileregex = re.compile(marcfile_prefix + ".*\." + marcfile_extension + "$")
-        #parse filename for datestamp e.g. alma_bibs__2018041306_6863237930003811_new_61.xml
-        datestampregex = re.compile(r"alma_bibs__(.*)_(.*).xml")
-        for infilename in marcdircontents:
-            if marcfileregex.search(infilename):
-                m = datestampregex.search(infilename)
-                if m is not None:
-                    datestamp = m.group(1)
-                    #  MAYBE TRY TO PARSE THESE OUT IN THE FUTURE?
-                    Variable.set("almaoai_last_num_oai_update_recs", 0)
-                    Variable.set("almaoai_last_num_oai_delete_recs", 0)
-                    Variable.set("almaoai_last_harvest_date", 0)
-                    break
-        date = time.strptime(datestamp[:8], "%Y%m%d")
-        Variable.set("almaoai_last_harvest_date", time.strftime(UTC_DATESTAMP_FSTR, date))
-        Variable.set("almaoai_last_harvest_from_date", time.strftime(UTC_DATESTAMP_FSTR, date))
+        datestamp = get_dump_date(marcdircontents)
+        if datestamp is not None:
+            #  MAYBE TRY TO PARSE THESE OUT IN THE FUTURE?
+            Variable.set("almaoai_last_num_oai_update_recs", 0)
+            Variable.set("almaoai_last_num_oai_delete_recs", 0)
+            date = time.strptime(datestamp[:8], "%Y%m%d")
+            Variable.set("almaoai_last_harvest_date", time.strftime(UTC_DATESTAMP_FSTR, date))
+            Variable.set("almaoai_last_harvest_from_date", time.strftime(UTC_DATESTAMP_FSTR, date))
+        else:
+            raise Exception("Cannot find a datestamp in {}".format(marcfilepath))
     else:
-        raise Exception(str(os.path.isfile(ingest_command)) + " Cannot locate {}".format(ingest_command))
+        raise Exception(str(os.path.isfile(ingest_command)) +
+                        " Cannot locate {}".format(ingest_command))
+
+def renamesftpfiles_onsuccess(ds, **kwargs):
+    marcdircontents = os.listdir(marcfilepath)
+    datestamp = get_dump_date(marcdircontents)
+    if datestamp is not None:
+        try:
+            # compress dump
+            zipfilename = "{}{}".format(MARCFILE_PREFIX, datestamp)
+            tarcmd = "cd {} && tar -cvzf {}.tar.gz {}*.xml".format(marcfilepath,
+                                                                   zipfilename,
+                                                                   MARCFILE_PREFIX)
+            print(tarcmd)
+            os.system(tarcmd)
+        except FileExistsError as ex:
+            print(str(ex))
+            # We already have this dump archived, so just delete the files
+            # in the finally block
+        finally:
+            delcmd = "cd {} && rm -f {}{}*.xml".format(marcfilepath,
+                                                       MARCFILE_PREFIX,
+                                                       datestamp)
+            print(delcmd)
+            os.system(delcmd)
+    else:
+        print("No previous sftp export to archive.")

--- a/scripts/git_pull_tul_cob.sh
+++ b/scripts/git_pull_tul_cob.sh
@@ -3,7 +3,7 @@
 # Argument 2, if arg 1 is not true, is any git ref or branch to switch to
 cd $HOME/tul_cob
 
-git fetch https://github.com/tulibraries/tul_cob.git  --tags
+git fetch https://github.com/tulibraries/cob_index.git  --tags
 git reset --hard HEAD
 
 if [ $1 == "true" ]; then

--- a/scripts/git_pull_tul_cob.sh
+++ b/scripts/git_pull_tul_cob.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Argument 1 is the LATEST_RELEASE flag, if "true" fetch latest tagged release
 # Argument 2, if arg 1 is not true, is any git ref or branch to switch to
-cd $HOME/tul_cob
+cd $HOME/cob_index
 
 git fetch https://github.com/tulibraries/cob_index.git  --tags
 git reset --hard HEAD

--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -3,6 +3,9 @@
 # Argument 2 is the SOLR URL
 # Argument 3 is the harvest-from date
 source $HOME/.bashrc
+echo $1
+echo $2
+echo $3
 whoami
 pwd
 echo $HOME

--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -19,7 +19,7 @@ then
   exit 1
 fi
 
-cd $HOME/tul_cob
+cd $HOME/cob_index
 gem install bundler
 bundle install
 SOLR_URL="$2" ALMAOAI_LAST_HARVEST_FROM_DATE="$3" bundle exec traject -c lib/traject/indexer_config.rb ${1}

--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -22,5 +22,5 @@ fi
 cd $HOME/cob_index
 gem install bundler
 bundle install
-SOLR_URL="$2" ALMAOAI_LAST_HARVEST_FROM_DATE="$3" bundle exec traject -c lib/traject/indexer_config.rb ${1}
+ SOLR_URL="$2" ALMAOAI_LAST_HARVEST_FROM_DATE="$3" bundle exec traject -c lib/cob_index/indexer_config.rb ${1}
 return 0

--- a/scripts/ingest_marc_multi.sh
+++ b/scripts/ingest_marc_multi.sh
@@ -1,5 +1,9 @@
 #!/bin/bash --login
+# Argument 1 is the directory containing MARCXML files to ingest
+# Argument 2 is the SOLR URL
 source $HOME/.bashrc
+echo $1
+echo $2
 whoami
 pwd
 echo $HOME

--- a/scripts/ingest_marc_multi.sh
+++ b/scripts/ingest_marc_multi.sh
@@ -12,7 +12,7 @@ which gem
 which bundle
 ruby -v
 
-cd $HOME/tul_cob
+cd $HOME/cob_index
 gem install bundler
 bundle install
 for f in $1/alma_bibs__*.xml


### PR DESCRIPTION
Debug printout cmd line vars in shell scripts. 
Increase timeout for sftp fetch because it ran long one time. 
Remove the solr replication tasks because we're not going that route.