### PR TITLE
Remove almafullreindex_inprogress variable.

### DIFF
--- a/task_almasftp.py
+++ b/task_almasftp.py
@@ -1,13 +1,11 @@
 from airflow import DAG
 from airflow import AirflowException
-from airflow.models import Variable
 from airflow.operators.python_operator import PythonOperator
 import os
 from cob_datapipeline.almasftp_fetch import almasftp_fetch
 
 
 def task_almasftp(dag):
-    Variable.set("almafullreindex_inprogress", True)
     t1 = PythonOperator(
         task_id='almasftp',
         python_callable=almasftp_fetch,


### PR DESCRIPTION
Setting this variable in task creation is causing it to get recreated
every time we try to edit it.  And, this seems to be causing an error
where task fails under certain conditions.