### PR TITLE
Make sure the BashOperator gets the return value of ingest_marc.sh...

### DIFF
--- a/scripts/ingest_marc.sh
+++ b/scripts/ingest_marc.sh
@@ -2,7 +2,10 @@
 # Argument 1 is the MARCXML file to ingest
 # Argument 2 is the SOLR URL
 # Argument 3 is the harvest-from date
+# Argument 4 is the Traject log file for future parsing
 source $HOME/.bashrc
+# print some information for future debugging
+set -ux
 echo $1
 echo $2
 echo $3
@@ -14,13 +17,17 @@ which gem
 which bundle
 ruby -v
 
+# check that the MARC XML file exists
 if [ ! -e ${1} ]
 then
   exit 1
 fi
 
-cd $HOME/cob_index
-gem install bundler
-bundle install
- SOLR_URL="$2" ALMAOAI_LAST_HARVEST_FROM_DATE="$3" bundle exec traject -c lib/cob_index/indexer_config.rb ${1}
-return 0
+# make sure the indexer config exists
+cd $HOME/cob_index || exit 1
+gem install bundler || exit 1
+bundle install || exit 1
+# ingest the MARC XML, teeing the output to a separate log file
+{
+SOLR_URL="$2" ALMAOAI_LAST_HARVEST_FROM_DATE="$3" bundle exec traject -c lib/cob_index/indexer_config.rb ${1}
+}  2>&1 | tee ${4}

--- a/task_ingestmarc.py
+++ b/task_ingestmarc.py
@@ -21,7 +21,7 @@ def ingest_marc(dag, marcfilename, taskid):
     if os.path.isfile(ingest_command):
         t1 = BashOperator(
             task_id=taskid,
-            bash_command="source {} {} {} {}  2>&1  | tee {}".format(ingest_command, infilename, solr_endpoint, harvest_from_date, logfile) + ' ',
+            bash_command="source {} {} {} {} {} 2>&1 ".format(ingest_command, infilename, solr_endpoint, harvest_from_date, logfile) + ' ',
             dag=dag
         )
     else:


### PR DESCRIPTION
Make ingest_marc.sh catch more error conditions.
Teeing the output of the ingest script made the BashOperator only see the return value of Tee (which generally succeeds).
Now we'll only Tee what needs to be teed and let the rest fail fast.
This also works well with the issue of traject barfing on solr 409 errors that we'd rather see swallowed.