### PR TITLE
WIP More catalog repairs

### DIFF
--- a/scripts/sc_ingest_marc.sh
+++ b/scripts/sc_ingest_marc.sh
@@ -22,5 +22,5 @@ data_in=$(aws s3api list-objects --bucket $BUCKET --prefix $FOLDER | jq -r '.Con
 
 for file in $data_in
 do
-  bundle exec cob_index ingest https://$BUCKET.s3.amazonaws.com/$file
+  bundle exec cob_index ingest http://$BUCKET.s3.amazonaws.com/$file
 done


### PR DESCRIPTION
JRuby does strict TLS checking, it seems, and it creates an error when trying to retrieve data from https S3 URL. There may be a fix in Traject (is Traject presuming an HTTP call when passed a URL?), there may be a better fix for JRuby (get it to force HTTPS when asked), but uncertain.