### PR TITLE
Use empty delimeter when listing s3 files.

### DIFF
--- a/qa_sc_catalog_oai_index_dag.py
+++ b/qa_sc_catalog_oai_index_dag.py
@@ -126,7 +126,7 @@ LIST_CATALOG_BW_S3_DATA = S3ListOperator(
     task_id="list_catalog_bw_s3_data",
     bucket=AIRFLOW_DATA_BUCKET,
     prefix=DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/bw/",
-    delimiter="/",
+    delimiter="",
     aws_conn_id=AIRFLOW_S3.conn_id,
     dag=DAG
 )


### PR DESCRIPTION
Using slash as our delimeter is causing None to be returned instead of a list of files.