### PR TITLE
Add TRAJECT_FULL_REINDEX variable to solrcloud dags

### DIFF
--- a/prod_sc_catalog_full_reindex_dag.py
+++ b/prod_sc_catalog_full_reindex_dag.py
@@ -138,6 +138,7 @@ INDEX_SFTP_MARC = BashOperator(
         "SOLR_AUTH_USER": SOLR_CONN.login or "",
         "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
         "SOLR_URL": tasks.get_solr_url(SOLR_CONN, CONFIGSET + "-{{ ti.xcom_pull(task_ids='set_collection_name') }}"),
+        "TRAJECT_FULL_REINDEX": "yes",
     },
     dag=DAG
 )

--- a/qa_sc_catalog_full_reindex_dag.py
+++ b/qa_sc_catalog_full_reindex_dag.py
@@ -138,6 +138,7 @@ INDEX_SFTP_MARC = BashOperator(
         "SOLR_AUTH_USER": SOLR_CONN.login or "",
         "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
         "SOLR_URL": tasks.get_solr_url(SOLR_CONN, CONFIGSET + "-{{ ti.xcom_pull(task_ids='set_collection_name') }}"),
+        "TRAJECT_FULL_REINDEX": "yes",
     },
     dag=DAG
 )

--- a/stage_sc_catalog_full_reindex_dag.py
+++ b/stage_sc_catalog_full_reindex_dag.py
@@ -138,6 +138,7 @@ INDEX_SFTP_MARC = BashOperator(
         "SOLR_AUTH_USER": SOLR_CONN.login or "",
         "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
         "SOLR_URL": tasks.get_solr_url(SOLR_CONN, CONFIGSET + "-{{ ti.xcom_pull(task_ids='set_collection_name') }}"),
+        "TRAJECT_FULL_REINDEX": "yes",
     },
     dag=DAG
 )


### PR DESCRIPTION
This variable is necessary to skip items that only include missing/lost/etc. process types.  The slorcloud dags don't currently pass this variable in, so the records are being ingested instead of skipped.