### PR TITLE
BL-1110 Fix update from date oai harvest broken

### DIFF
--- a/prod_sc_catalog_oai_index_dag.py
+++ b/prod_sc_catalog_oai_index_dag.py
@@ -214,7 +214,7 @@ UPDATE_DATE_VARIABLES = PythonOperator(
     python_callable=update_variables,
     op_kwargs={
         "UPDATE": {
-            "CATALOG_HARVEST_FROM_DATE": CATALOG_HARVEST_FROM_DATE_NEW
+            "CATALOG_PROD_HARVEST_FROM_DATE": CATALOG_HARVEST_FROM_DATE_NEW
         }
     },
     dag=DAG

--- a/qa_sc_catalog_oai_index_dag.py
+++ b/qa_sc_catalog_oai_index_dag.py
@@ -214,7 +214,7 @@ UPDATE_DATE_VARIABLES = PythonOperator(
     python_callable=update_variables,
     op_kwargs={
         "UPDATE": {
-            "CATALOG_HARVEST_FROM_DATE": CATALOG_HARVEST_FROM_DATE_NEW
+            "CATALOG_QA_HARVEST_FROM_DATE": CATALOG_HARVEST_FROM_DATE_NEW
         }
     },
     dag=DAG

--- a/stage_sc_catalog_oai_index_dag.py
+++ b/stage_sc_catalog_oai_index_dag.py
@@ -214,7 +214,7 @@ UPDATE_DATE_VARIABLES = PythonOperator(
     python_callable=update_variables,
     op_kwargs={
         "UPDATE": {
-            "CATALOG_HARVEST_FROM_DATE": CATALOG_HARVEST_FROM_DATE_NEW
+            "CATALOG_STAGE_HARVEST_FROM_DATE": CATALOG_HARVEST_FROM_DATE_NEW
         }
     },
     dag=DAG


### PR DESCRIPTION
The update from date needs to be envrionment specific in order to work in the current dag.

This commit makes this variable environment specific.