### PR TITLE
Bl 1107 add commit task

### DIFF
--- a/prod_sc_catalog_full_reindex_dag.py
+++ b/prod_sc_catalog_full_reindex_dag.py
@@ -5,6 +5,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.contrib.operators.s3_list_operator import S3ListOperator
 from cob_datapipeline.sc_xml_parse import prepare_boundwiths, prepare_alma_data
 from cob_datapipeline.task_sc_get_num_docs import task_solrgetnumdocs

--- a/qa_sc_catalog_full_reindex_dag.py
+++ b/qa_sc_catalog_full_reindex_dag.py
@@ -5,6 +5,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.contrib.operators.s3_list_operator import S3ListOperator
 from cob_datapipeline.sc_xml_parse import prepare_boundwiths, prepare_alma_data
 from cob_datapipeline.task_sc_get_num_docs import task_solrgetnumdocs

--- a/qa_sc_catalog_full_reindex_dag.py
+++ b/qa_sc_catalog_full_reindex_dag.py
@@ -166,6 +166,17 @@ SOLR_ALIAS_SWAP = tasks.swap_sc_alias(
     CONFIGSET + "-qa"
 )
 
+SOLR_COMMIT = SimpleHttpOperator(
+    task_id='solr_commit',
+    method='GET',
+    http_conn_id=SOLR_CONN.conn_id,
+    endpoint= '/solr/' + ALIAS + '/update',
+    data={"stream.body": "<commit/>"},
+    xcom_push=True,
+    headers={},
+    dag=DAG
+)
+
 GET_NUM_SOLR_DOCS_POST = task_solrgetnumdocs(
     DAG,
     CONFIGSET +"-{{ ti.xcom_pull(task_ids='set_collection_name') }}",
@@ -189,5 +200,6 @@ CREATE_COLLECTION.set_upstream(PREPARE_ALMA_DATA)
 INDEX_SFTP_MARC.set_upstream(CREATE_COLLECTION)
 ARCHIVE_S3_DATA.set_upstream(INDEX_SFTP_MARC)
 SOLR_ALIAS_SWAP.set_upstream(ARCHIVE_S3_DATA)
-GET_NUM_SOLR_DOCS_POST.set_upstream(SOLR_ALIAS_SWAP)
+SOLR_COMMIT.set_upstream(SOLR_ALIAS_SWAP)
+GET_NUM_SOLR_DOCS_POST.set_upstream(SOLR_COMMIT)
 POST_SLACK.set_upstream(GET_NUM_SOLR_DOCS_POST)

--- a/stage_sc_catalog_full_reindex_dag.py
+++ b/stage_sc_catalog_full_reindex_dag.py
@@ -5,7 +5,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.operators.http_operator import import SimpleHttpOperator
+from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.contrib.operators.s3_list_operator import S3ListOperator
 from cob_datapipeline.sc_xml_parse import prepare_boundwiths, prepare_alma_data
 from cob_datapipeline.task_sc_get_num_docs import task_solrgetnumdocs

--- a/stage_sc_catalog_full_reindex_dag.py
+++ b/stage_sc_catalog_full_reindex_dag.py
@@ -166,6 +166,17 @@ SOLR_ALIAS_SWAP = tasks.swap_sc_alias(
     CONFIGSET + "-stage"
 )
 
+SOLR_COMMIT = SimpleHttpOperator(
+    task_id='solr_commit',
+    method='GET',
+    http_conn_id=SOLR_CONN.conn_id,
+    endpoint= '/solr/' + ALIAS + '/update',
+    data={"stream.body": "<commit/>"},
+    xcom_push=True,
+    headers={},
+    dag=DAG
+)
+
 GET_NUM_SOLR_DOCS_POST = task_solrgetnumdocs(
     DAG,
     CONFIGSET +"-{{ ti.xcom_pull(task_ids='set_collection_name') }}",
@@ -189,5 +200,6 @@ CREATE_COLLECTION.set_upstream(PREPARE_ALMA_DATA)
 INDEX_SFTP_MARC.set_upstream(CREATE_COLLECTION)
 ARCHIVE_S3_DATA.set_upstream(INDEX_SFTP_MARC)
 SOLR_ALIAS_SWAP.set_upstream(ARCHIVE_S3_DATA)
-GET_NUM_SOLR_DOCS_POST.set_upstream(SOLR_ALIAS_SWAP)
+SOLR_COMMIT.set_upstream(SOLR_ALIAS_SWAP)
+GET_NUM_SOLR_DOCS_POST.set_upstream(SOLR_COMMIT)
 POST_SLACK.set_upstream(GET_NUM_SOLR_DOCS_POST)

--- a/stage_sc_catalog_full_reindex_dag.py
+++ b/stage_sc_catalog_full_reindex_dag.py
@@ -5,6 +5,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.operators.http_operator import import SimpleHttpOperator
 from airflow.contrib.operators.s3_list_operator import S3ListOperator
 from cob_datapipeline.sc_xml_parse import prepare_boundwiths, prepare_alma_data
 from cob_datapipeline.task_sc_get_num_docs import task_solrgetnumdocs

--- a/tests/prod_sc_catalog_full_reindex_dag_test.py
+++ b/tests/prod_sc_catalog_full_reindex_dag_test.py
@@ -27,6 +27,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "index_sftp_marc",
             "archive_s3_data",
             "solr_alias_swap",
+            "solr_commit",
             "get_num_solr_docs_post",
             "slack_post_succ"
             ])
@@ -42,6 +43,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "index_sftp_marc": ["create_collection"],
             "archive_s3_data": ["index_sftp_marc"],
             "solr_alias_swap": ["archive_s3_data"],
+            "solr_commit": ["solr_alias_swap"],
             "get_num_solr_docs_post": ["solr_alias_swap"],
             "slack_post_succ": ["get_num_solr_docs_post"],
         }

--- a/tests/prod_sc_catalog_full_reindex_dag_test.py
+++ b/tests/prod_sc_catalog_full_reindex_dag_test.py
@@ -44,7 +44,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "archive_s3_data": ["index_sftp_marc"],
             "solr_alias_swap": ["archive_s3_data"],
             "solr_commit": ["solr_alias_swap"],
-            "get_num_solr_docs_post": ["solr_alias_swap"],
+            "get_num_solr_docs_post": ["solr_commit"],
             "slack_post_succ": ["get_num_solr_docs_post"],
         }
         for task, upstream_tasks in expected_task_deps.items():

--- a/tests/qa_sc_catalog_full_reindex_dag_test.py
+++ b/tests/qa_sc_catalog_full_reindex_dag_test.py
@@ -27,6 +27,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "index_sftp_marc",
             "archive_s3_data",
             "solr_alias_swap",
+            "solr_commit",
             "get_num_solr_docs_post",
             "slack_post_succ"
             ])
@@ -42,7 +43,8 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "index_sftp_marc": ["create_collection"],
             "archive_s3_data": ["index_sftp_marc"],
             "solr_alias_swap": ["archive_s3_data"],
-            "get_num_solr_docs_post": ["solr_alias_swap"],
+            "solr_commit": ["solr_alias_swap"],
+            "get_num_solr_docs_post": ["solr_commit"],
             "slack_post_succ": ["get_num_solr_docs_post"],
         }
         for task, upstream_tasks in expected_task_deps.items():

--- a/tests/stage_sc_catalog_full_reindex_dag_test.py
+++ b/tests/stage_sc_catalog_full_reindex_dag_test.py
@@ -27,6 +27,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "index_sftp_marc",
             "archive_s3_data",
             "solr_alias_swap",
+            "solr_commit",
             "get_num_solr_docs_post",
             "slack_post_succ"
             ])
@@ -42,6 +43,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "index_sftp_marc": ["create_collection"],
             "archive_s3_data": ["index_sftp_marc"],
             "solr_alias_swap": ["archive_s3_data"],
+            "solr_commit": ["solr_alias_swap"],
             "get_num_solr_docs_post": ["solr_alias_swap"],
             "slack_post_succ": ["get_num_solr_docs_post"],
         }

--- a/tests/stage_sc_catalog_full_reindex_dag_test.py
+++ b/tests/stage_sc_catalog_full_reindex_dag_test.py
@@ -44,7 +44,7 @@ class TestCatalogFullReindexScDag(unittest.TestCase):
             "archive_s3_data": ["index_sftp_marc"],
             "solr_alias_swap": ["archive_s3_data"],
             "solr_commit": ["solr_alias_swap"],
-            "get_num_solr_docs_post": ["solr_alias_swap"],
+            "get_num_solr_docs_post": ["solr_commit"],
             "slack_post_succ": ["get_num_solr_docs_post"],
         }
         for task, upstream_tasks in expected_task_deps.items():


### PR DESCRIPTION
- Currently, there is no commit at the end of the ingest task so the slack numbers are not accurate.
- This adds a commit task before the slack post for more accuracy in reporting