### PR TITLE
Add s3_to_sftp task per alma notes type.

### DIFF
--- a/tests/alma_electronic_notes_dag_test.py
+++ b/tests/alma_electronic_notes_dag_test.py
@@ -20,7 +20,8 @@ class TestAlmaElectronicNotesDag(unittest.TestCase):
         self.assertEqual(self.tasks, [
             "set_datetime",
             "harvest_notes",
-            "s3_to_server",
+            "s3_to_server_collection",
+            "s3_to_server_service",
             "reload_electronic_notes",
             ])
 


### PR DESCRIPTION
Fixes S3_TO_FTP task broken.

Replaces task with dynamic list of task.