### PR TITLE
Remove extraneous base hook import

### DIFF
--- a/cob_datapipeline/catalog_move_alma_sftp_to_s3_dag.py
+++ b/cob_datapipeline/catalog_move_alma_sftp_to_s3_dag.py
@@ -6,7 +6,6 @@ import logging
 import airflow
 from airflow.models import Variable
 from airflow.contrib.hooks.sftp_hook import SFTPHook
-from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.bash_operator import BashOperator
 


### PR DESCRIPTION
Was a hold over from when the custom Operator was defined in this file. No longer required.