### PR TITLE
Better slack message for move sftp to s3

### DIFF
--- a/cob_datapipeline/catalog_move_alma_sftp_to_s3_dag.py
+++ b/cob_datapipeline/catalog_move_alma_sftp_to_s3_dag.py
@@ -103,7 +103,7 @@ ARCHIVE_FILES_IN_SFTP = PythonOperator(
 
 def slackpostonsuccess(**context):
     most_recent_date = context['task_instance'].xcom_pull(task_ids='archive_files_in_sftp', key='most_recent_date' )
-    count = context['task_instance'].xcom_pull(task_ids='get_list_of_alma_sftp_files_to_transer' )
+    count = context['task_instance'].xcom_pull(task_ids='archive_files_in_sftp' )
     msg = f"{count} files moved from sftp to s3 in almasftp/{most_recent_date} and then archived on the sftp server in archive/{most_recent_date}"
     return tasks.execute_slackpostonsuccess(context, conn_id="COB_SLACK_WEBHOOK", message=msg)
 


### PR DESCRIPTION
It helps to select the xcom from the correct previous task when
constructing an error message.