### PR TITLE
Fix collection name Jinja template.

### DIFF
--- a/cob_datapipeline/helpers.py
+++ b/cob_datapipeline/helpers.py
@@ -15,7 +15,7 @@ def catalog_safety_check(**context):
         raise Exception("The pre production collection cannot be equal to the production collection.")
 
 def catalog_collection_name(configset, cob_index_version):
-    default_name = "{{ configset }}.{{ cob_index_version }}-{{ ti.xcom_pull(task_ids='set_s3_namespace') }}"
+    default_name = f"{ configset }.{ cob_index_version }" + "-{{ ti.xcom_pull(task_ids='set_s3_namespace') }}"
 
     configured_name = Variable.get("CATALOG_PRE_PRODUCTION_SOLR_COLLECTION", default_name)
 

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -35,7 +35,7 @@ class TestDetermineMostRecentDate(unittest.TestCase):
         name = helpers.catalog_collection_name(
                 configset="bizz",
                 cob_index_version="buzz")
-        expected_name = "{{ configset }}.{{ cob_index_version }}-{{ ti.xcom_pull(task_ids='set_s3_namespace') }}"
+        expected_name = "bizz.buzz-{{ ti.xcom_pull(task_ids='set_s3_namespace') }}"
         self.assertEqual(name, expected_name)
 
         # When CATALOG_PRE_PRODUCTION_SOLR_COLLECTION is not defined
@@ -43,7 +43,7 @@ class TestDetermineMostRecentDate(unittest.TestCase):
         name = helpers.catalog_collection_name(
                 configset="bizz",
                 cob_index_version="buzz")
-        expected_name = "{{ configset }}.{{ cob_index_version }}-{{ ti.xcom_pull(task_ids='set_s3_namespace') }}"
+        expected_name = "bizz.buzz-{{ ti.xcom_pull(task_ids='set_s3_namespace') }}"
         self.assertEqual(name, expected_name)
 
     @requests_mock.mock()


### PR DESCRIPTION
`configset` and `cob_index_version` should already be parsed in the Jinja template.

Otherwise, they are null.