### PR TITLE
Limit the CD to only deploy dags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             pipenv run ansible-galaxy install -r requirements.yml
             cp .circleci/.vault ~/.vault;
             chmod +x ~/.vault
-            pipenv run ansible-playbook -i inventory/qa playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
+            pipenv run ansible-playbook -i inventory/qa playbook.yml --tags "jumphost,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
   prod_deploy:
     docker:
       - image: circleci/python:3.6
@@ -59,7 +59,7 @@ jobs:
             pipenv run ansible-galaxy install -r requirements.yml
             cp .circleci/.vault ~/.vault;
             chmod +x ~/.vault
-            pipenv run ansible-playbook -i inventory/prod playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' -e cob_datapipeline_branch=$CIRCLE_TAG
+            pipenv run ansible-playbook -i inventory/prod playbook.yml --tags "jumphost,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' -e cob_datapipeline_branch=$CIRCLE_TAG
 
 workflows:
   version: 2


### PR DESCRIPTION
This means the each change to a repo does not run the entire airflow playbook, but only the parts that update dags. Needs to run the jumphost role so it can connect.