### PR TITLE
Add dummy value to required ansible variable.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             pipenv run ansible-galaxy install -r requirements.yml
             cp .circleci/.vault ~/.vault;
             chmod +x ~/.vault
-            pipenv run ansible-playbook -i inventory/qa playbook.yml --tags "jumphost,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
+            pipenv run ansible-playbook -i inventory/qa playbook.yml --tags "jumphost,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' -e _airflow_python_version=None
   prod_deploy:
     docker:
       - image: circleci/python:3.6
@@ -59,7 +59,7 @@ jobs:
             pipenv run ansible-galaxy install -r requirements.yml
             cp .circleci/.vault ~/.vault;
             chmod +x ~/.vault
-            pipenv run ansible-playbook -i inventory/prod playbook.yml --tags "jumphost,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' -e cob_datapipeline_branch=$CIRCLE_TAG
+            pipenv run ansible-playbook -i inventory/prod playbook.yml --tags "jumphost,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' -e cob_datapipeline_branch=$CIRCLE_TAG -e _airflow_python_version=None
 
 workflows:
   version: 2


### PR DESCRIPTION
The ansible airflow playbook has a dependency on the
_airflow_python_version variable.  But, the variable is not actually
used in this deployment context (i.e. deploying just the dags).

This commit adds a dummy value to this variable in order to avoid
ansible throwing an error.

Note this variable usually gets set here:
https://github.com/tulibraries/ansible-role-airflow/blob/b2848e46082675605aaf9646d720b10078c78413/vars/os_distribution/centos.yml