### PR TITLE
DEVO-229: Move processed files to another folder

### DIFF
--- a/cob_datapipeline/scripts/sc_ingest_marc.sh
+++ b/cob_datapipeline/scripts/sc_ingest_marc.sh
@@ -28,4 +28,6 @@ for file in $data_in
 do
   echo "Indexing file: "$file
   bundle exec cob_index $COMMAND $(aws s3 presign s3://$BUCKET/$file)
+  processed_file=$(echo $file | sed 's/new-updated/processed-new-updated/' | sed 's/deleted/processed-deleted/')
+  aws s3 mv s3://$BUCKET/$file s3://$BUCKET/$processed_file
 done


### PR DESCRIPTION
REF DEVO-229

Sometimes there are many files that need to be
ingested/deleted/suppressed and the task fails halfway in and then
starts right back from the beginning.

This change would avoid re-ingesting or deleting/suppressing a file that
has already been processed in an earlier failed task. Thus potentially
minimizing recovery time.

This change would also have the added benefit that in the case where
recovery is not possible because of a corrupt file, then that corrupt
file would be first on the list which can potentially reduce debugging
time.