### PR TITLE
Skip moving s3 files when src and dest are equal.

### DIFF
--- a/cob_datapipeline/scripts/sc_ingest_marc.sh
+++ b/cob_datapipeline/scripts/sc_ingest_marc.sh
@@ -29,5 +29,9 @@ do
   echo "Indexing file: "$file
   bundle exec cob_index $COMMAND $(aws s3 presign s3://$BUCKET/$file)
   processed_file=$(echo $file | sed 's/new-updated/processed-new-updated/' | sed 's/deleted/processed-deleted/')
-  aws s3 mv s3://$BUCKET/$file s3://$BUCKET/$processed_file
+
+  # In full reindex context $file and $processed_file are equal.
+  if [ "$file" != "$processed_file" ]; then
+    aws s3 mv s3://$BUCKET/$file s3://$BUCKET/$processed_file
+  fi
 done


### PR DESCRIPTION
We don't have a straight forward way to update file paths for processed files
in full reindex context.  This is a quick fix to avoid error were we try
to s3 mv a file to itself (i.e. source and destination are equal).

TODO: Alma SFTP dump should go to  a subfolder so that we can easily add the
same efficiency step we use in harvest context to the full reindex context.