### PR TITLE
troubleshooting transform error

### DIFF
--- a/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
+++ b/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
@@ -38,9 +38,9 @@
 
             <!-- Variables -->
 
-            <xsl:variable name="thesisDate" select="//element[@name='date']/element[@name='issued']/element/field[@name='value']" />
+            <xsl:variable name="thesisDate" select="//element[@name='date']/element[@name='issued'][1]/element/field[@name='value']" />
             <xsl:variable name="thesisYear">
-                <xsl:value-of select="substring($thesisDate, 1,4)"/>
+                <xsl:value-of select="substring($thesisDate,1,4)"/>
             </xsl:variable>
             <xsl:variable name="thesisLanguage" select="element[@name='language']/element[@name='iso']/element/field[@name='value']" />
             <xsl:variable name="thesisTitle" select="element[@name='title']/element/field[@name='value'][1]" />


### PR DESCRIPTION
Updating date variable to attempt to fix Saxon error in DAG run; it appears there is a record that contains more than one date, so I have updated the xpath to only look for 1st occurrence of date issued

Error message:
A sequence of more than one item is not allowed as the first argument of fn:substring() ("2016", "2018")