### PR TITLE
Update xpath for date variable

### DIFF
--- a/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
+++ b/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
@@ -170,7 +170,7 @@
                     </subfield>
                     <subfield code="c">
                         <xsl:if test="contains($thesisAuthor, ',')">
-                            <xsl:text xml:space="preserve">by </xsl:text>
+                            <xsl:text xml:space="preserve">by</xsl:text>
                             <xsl:value-of select="substring-after($thesisAuthor,',')"/>
                             <xsl:text xml:space="preserve"> </xsl:text>
                             <xsl:value-of select="substring-before($thesisAuthor,',')"/>

--- a/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
+++ b/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
@@ -38,11 +38,10 @@
 
             <!-- Variables -->
 
-            <xsl:variable name="thesisDate" select="//element[@name='date']/element[@name='issued']/element/field[@name='value']" />
-            <!--
+            <xsl:variable name="thesisDate" select="element[@name='date']/element[@name='issued']/element/field[@name='value']" />
             <xsl:variable name="thesisYear">
                 <xsl:value-of select="substring($thesisDate,1,4)"/>
-            </xsl:variable>-->
+            </xsl:variable>
             <xsl:variable name="thesisLanguage" select="element[@name='language']/element[@name='iso']/element/field[@name='value']" />
             <xsl:variable name="thesisTitle" select="element[@name='title']/element/field[@name='value'][1]" />
             <xsl:variable name="thesisAuthor" select="element[@name='creator']/element/field[@name='value']" />
@@ -62,7 +61,7 @@
             <controlfield tag="008">
                 <xsl:text>000000</xsl:text>
                 <xsl:text xml:space="preserve">s</xsl:text>
-                <xsl:value-of select="$thesisDate"/>
+                <xsl:value-of select="$thesisYear"/>
                 <xsl:text xml:space="preserve">\\\\pau\\\\\obm\\\000\0\</xsl:text>
                 <xsl:value-of select="$thesisLanguage"/>
                 <xsl:text xml:space="preserve">\d</xsl:text>
@@ -216,7 +215,7 @@
                     <xsl:text xml:space="preserve">Temple University Libraries, </xsl:text>
                 </subfield>
                 <subfield code="c">
-                    <xsl:value-of select="$thesisDate" />.
+                    <xsl:value-of select="$thesisYear" />.
                 </subfield>
             </datafield>
 


### PR DESCRIPTION
- Updates xpath for date variable; turns out the change from xslt1.0 to xslt2.0 makes the value-of element more "grabby," so it was pulling in all the dates instead of just one.

Thanks for your patience, this should really be the last one! (fingers crossed)