### PR TITLE
BL-1566: Fix web content, az index broken after lets encrypt.

### DIFF
--- a/cob_datapipeline/prod_az_reindex_dag.py
+++ b/cob_datapipeline/prod_az_reindex_dag.py
@@ -24,7 +24,7 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 SCHEDULE_INTERVAL = Variable.get("AZ_INDEX_SCHEDULE_INTERVAL")
 
 # Get Solr URL & Collection Name for indexing info; error out if not entered
-SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
+SOLR_CONN = BaseHook.get_connection("SOLRCLOUD-WRITER")
 SOLR_CONFIG = Variable.get("AZ_SOLR_CONFIG", deserialize_json=True)
 # {"configset": "tul_cob-az-2", "replication_factor": 4}
 CONFIGSET = SOLR_CONFIG.get("configset")

--- a/cob_datapipeline/prod_web_content_reindex_dag.py
+++ b/cob_datapipeline/prod_web_content_reindex_dag.py
@@ -23,7 +23,7 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 SCHEDULE_INTERVAL = Variable.get("WEB_CONTENT_SCHEDULE_INTERVAL")
 
 # Get Solr URL & Collection Name for indexing info; error out if not entered
-SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
+SOLR_CONN = BaseHook.get_connection("SOLRCLOUD-WRITER")
 SOLR_CONFIG = Variable.get("WEB_CONTENT_SOLR_CONFIG", deserialize_json=True)
 # {"configset": "tul_cob-web-2", "replication_factor": 4}
 CONFIGSET = SOLR_CONFIG.get("configset")

--- a/cob_datapipeline/qa_az_reindex_dag.py
+++ b/cob_datapipeline/qa_az_reindex_dag.py
@@ -24,7 +24,7 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 SCHEDULE_INTERVAL = Variable.get("AZ_INDEX_SCHEDULE_INTERVAL")
 
 # Get Solr URL & Collection Name for indexing info; error out if not entered
-SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
+SOLR_CONN = BaseHook.get_connection("SOLRCLOUD-WRITER")
 SOLR_CONFIG = Variable.get("AZ_SOLR_CONFIG_QA", deserialize_json=True)
 # {"configset": "tul_cob-az-2", "replication_factor": 4}
 CONFIGSET = SOLR_CONFIG.get("configset")

--- a/cob_datapipeline/qa_web_content_reindex_dag.py
+++ b/cob_datapipeline/qa_web_content_reindex_dag.py
@@ -23,7 +23,7 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 SCHEDULE_INTERVAL = Variable.get("WEB_CONTENT_SCHEDULE_INTERVAL")
 
 # Get Solr URL & Collection Name for indexing info; error out if not entered
-SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
+SOLR_CONN = BaseHook.get_connection("SOLRCLOUD-WRITER")
 SOLR_CONFIG = Variable.get("WEB_CONTENT_SOLR_CONFIG", deserialize_json=True)
 # {"configset": "tul_cob-web-2", "replication_factor": 4}
 CONFIGSET = SOLR_CONFIG.get("configset")


### PR DESCRIPTION
Temporarily switch to using internal ip address for solr so that we
dont' have to go through https and run into that letsencrypt issue in
traject.