### PR TITLE
BL-1609: remove <collection> tag from transform

### DIFF
--- a/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
+++ b/cob_datapipeline/files/TEU_XOAItoMARCXML.xsl
@@ -13,9 +13,9 @@
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
     <xsl:template match="/">
-        <collection>
+        
             <xsl:apply-templates />
-        </collection>
+        
     </xsl:template>
 
     <xsl:template match="text()" />


### PR DESCRIPTION
- removes <collection> parent tag from xsl transform. 

Airflow already generates a <collection> parent tag. Multiple <collection> tags are causing MARCXML import to fail in Alma. Testing this to see if it will address the problem. 