### PR TITLE
Add the airflow tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             pipenv run ansible-galaxy install -r requirements.yml
             cp .circleci/.vault ~/.vault;
             chmod +x ~/.vault
-            pipenv run ansible-playbook -i inventory/qa playbook.yml --tags "jumphost,role::airflow::config,role::airflow::dags" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
+            pipenv run ansible-playbook -i inventory/qa playbook.yml --tags "jumphost,airflow" --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
   prod_deploy:
     docker:
       - image: cimg/python:3.9.10


### PR DESCRIPTION
There is something in the playbook that the dags tasks need that it isn't getting with our previous configuration.  This is a temporary solution to get the needed changes to QA, but we should narrow down which tasks actually need to be run as a next step.