### PR TITLE
DEVO-569-datetime-updates

### DIFF
--- a/cob_datapipeline/alma_electronic_notes_dag.py
+++ b/cob_datapipeline/alma_electronic_notes_dag.py
@@ -56,10 +56,9 @@ Tasks with all logic contained in a single operator can be declared here.
 Tasks with custom logic are relegated to individual Python files.
 """
 
-SET_DATETIME = PythonOperator(
+SET_DATETIME = BashOperator(
     task_id="set_datetime",
-    python_callable=datetime.now().strftime,
-    op_args=["%Y-%m-%d_%H-%M-%S"],
+    bash_command='echo ' + "{{ data_interval_start.strftime('%Y-%m-%d_%H-%M-%S') }}",
     dag=DAG
 )
 

--- a/cob_datapipeline/catalog_preproduction_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_preproduction_oai_harvest_dag.py
@@ -27,8 +27,8 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 CATALOG_OAI_PUBLISH_INTERVAL = Variable.get("CATALOG_OAI_PUBLISH_INTERVAL")
 CATALOG_HARVEST_FROM_DATE = Variable.get("CATALOG_PRE_PRODUCTION_HARVEST_FROM_DATE")
 CATALOG_LAST_HARVEST_FROM_DATE = Variable.get("CATALOG_PRE_PRODUCTION_LAST_HARVEST_FROM_DATE")
-S3_NAME_SPACE = '{{ execution_date.strftime("%Y-%m-%d_%H-%M-%S") }}'
-DEFAULT_HARVEST_UNTIL_DATE = '{{ execution_date.strftime("%Y-%m-%dT%H:%M:%SZ") }}'
+S3_NAME_SPACE = '{{ data_interval_start.strftime("%Y-%m-%d_%H-%M-%S") }}'
+DEFAULT_HARVEST_UNTIL_DATE = '{{ data_interval_start.strftime("%Y-%m-%dT%H:%M:%SZ") }}'
 CATALOG_HARVEST_UNTIL_DATE = Variable.get("CATALOG_HARVEST_UNTIL_DATE", default_var=DEFAULT_HARVEST_UNTIL_DATE)
 
 # Alma OAI Harvest Variables (besides Dates)

--- a/cob_datapipeline/catalog_production_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_production_oai_harvest_dag.py
@@ -27,8 +27,8 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 CATALOG_OAI_PUBLISH_INTERVAL = Variable.get("CATALOG_OAI_PUBLISH_INTERVAL")
 CATALOG_HARVEST_FROM_DATE = Variable.get("CATALOG_PROD_HARVEST_FROM_DATE")
 CATALOG_LAST_HARVEST_FROM_DATE = Variable.get("CATALOG_PROD_LAST_HARVEST_FROM_DATE")
-S3_NAME_SPACE = '{{ execution_date.strftime("%Y-%m-%d_%H-%M-%S") }}'
-DEFAULT_HARVEST_UNTIL_DATE = '{{ execution_date.strftime("%Y-%m-%dT%H:%M:%SZ") }}'
+S3_NAME_SPACE = '{{ data_interval_start.strftime("%Y-%m-%d_%H-%M-%S") }}'
+DEFAULT_HARVEST_UNTIL_DATE = '{{ data_interval_start.strftime("%Y-%m-%dT%H:%M:%SZ") }}'
 CATALOG_HARVEST_UNTIL_DATE = Variable.get("CATALOG_PROD_HARVEST_UNTIL_DATE", default_var=DEFAULT_HARVEST_UNTIL_DATE)
 
 # Alma OAI Harvest Variables (besides Dates)

--- a/cob_datapipeline/dspace_harvest_dag.py
+++ b/cob_datapipeline/dspace_harvest_dag.py
@@ -23,11 +23,11 @@ AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
 # Get S3 data bucket variables
 AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")
 AIRFLOW_DATA_BUCKET = Variable.get("AIRFLOW_DATA_BUCKET")
-S3_NAME_SPACE = '{{ execution_date.strftime("%Y-%m-%d_%H-%M-%S") }}'
+S3_NAME_SPACE = '{{ data_interval_start.strftime("%Y-%m-%d_%H-%M-%S") }}'
 
 # OAI Harvest Variables
 DSPACE_HARVEST_FROM_DATE = Variable.get("DSPACE_HARVEST_FROM_DATE")
-DEFAULT_HARVEST_UNTIL_DATE = '{{ execution_date.strftime("%Y-%m-%dT%H:%M:%SZ") }}'
+DEFAULT_HARVEST_UNTIL_DATE = '{{ data_interval_start.strftime("%Y-%m-%dT%H:%M:%SZ") }}'
 DSPACE_HARVEST_UNTIL_DATE = Variable.get("DSPACE_HARVEST_UNTIL_DATE", default_var=DEFAULT_HARVEST_UNTIL_DATE)
 DSPACE_OAI_CONFIG = Variable.get("DSPACE_OAI_CONFIG", deserialize_json=True)
 DSPACE_OAI_MD_PREFIX = DSPACE_OAI_CONFIG.get("md_prefix")

--- a/cob_datapipeline/prod_az_reindex_dag.py
+++ b/cob_datapipeline/prod_az_reindex_dag.py
@@ -62,10 +62,9 @@ Tasks with all logic contained in a single operator can be declared here.
 Tasks with custom logic are relegated to individual Python files.
 """
 
-SET_COLLECTION_NAME = PythonOperator(
-    task_id='set_collection_name',
-    python_callable=datetime.now().strftime,
-    op_args=["%Y-%m-%d_%H-%M-%S"],
+SET_COLLECTION_NAME = BashOperator(
+    task_id="set_collection_name",
+    bash_command='echo ' + "{{ data_interval_start.strftime('%Y-%m-%d_%H-%M-%S') }}",
     dag=DAG
 )
 

--- a/cob_datapipeline/prod_web_content_reindex_dag.py
+++ b/cob_datapipeline/prod_web_content_reindex_dag.py
@@ -61,10 +61,9 @@ Tasks with all logic contained in a single operator can be declared here.
 Tasks with custom logic are relegated to individual Python files.
 """
 
-SET_COLLECTION_NAME = PythonOperator(
-    task_id='set_collection_name',
-    python_callable=datetime.now().strftime,
-    op_args=["%Y-%m-%d_%H-%M-%S"],
+SET_COLLECTION_NAME = BashOperator(
+    task_id="set_collection_name",
+    bash_command='echo ' + "{{ data_interval_start.strftime('%Y-%m-%d_%H-%M-%S') }}",
     dag=DAG
 )
 

--- a/cob_datapipeline/qa_az_reindex_dag.py
+++ b/cob_datapipeline/qa_az_reindex_dag.py
@@ -62,10 +62,9 @@ Tasks with all logic contained in a single operator can be declared here.
 Tasks with custom logic are relegated to individual Python files.
 """
 
-SET_COLLECTION_NAME = PythonOperator(
+SET_COLLECTION_NAME = BashOperator(
     task_id="set_collection_name",
-    python_callable=datetime.now().strftime,
-    op_args=["%Y-%m-%d_%H-%M-%S"],
+    bash_command='echo ' + "{{ data_interval_start.strftime('%Y-%m-%d_%H-%M-%S') }}",
     dag=DAG
 )
 

--- a/cob_datapipeline/qa_web_content_reindex_dag.py
+++ b/cob_datapipeline/qa_web_content_reindex_dag.py
@@ -66,10 +66,9 @@ Tasks with all logic contained in a single operator can be declared here.
 Tasks with custom logic are relegated to individual Python files.
 """
 
-SET_COLLECTION_NAME = PythonOperator(
+SET_COLLECTION_NAME = BashOperator(
     task_id="set_collection_name",
-    python_callable=datetime.now().strftime,
-    op_args=["%Y-%m-%d_%H-%M-%S"],
+    bash_command='echo ' + "{{ data_interval_start.strftime('%Y-%m-%d_%H-%M-%S') }}",
     dag=DAG
 )
 

--- a/cob_datapipeline/tasks/task_slack_posts.py
+++ b/cob_datapipeline/tasks/task_slack_posts.py
@@ -16,7 +16,7 @@ def slackpostonsuccess(**context):
     ti = context.get('task_instance')
     logurl = ti.log_url
     dagid = ti.dag_id
-    date = context.get('execution_date')
+    date = context.get('data_interval_start')
     response_pre = ti.xcom_pull(task_ids='get_num_solr_docs_pre')
     ndocs_pre = json.loads(response_pre)["response"]["numFound"]
     response_post = ti.xcom_pull(task_ids='get_num_solr_docs_post')
@@ -43,7 +43,7 @@ def az_slackpostonsuccess(dag, **context):
     ti = context.get('task_instance')
     logurl = ti.log_url
     dagid = ti.dag_id
-    date = context.get('execution_date')
+    date = context.get('data_interval_start')
     response_pre = ti.xcom_pull(task_ids='get_num_solr_docs_pre')
     ndocs_pre = json.loads(response_pre)["response"]["numFound"]
     response_post = ti.xcom_pull(task_ids='get_num_solr_docs_post')
@@ -75,7 +75,7 @@ def full_reindex_slack_post_on_success(**context):
     ti = context.get('task_instance')
     logurl = ti.log_url
     dagid = ti.dag_id
-    date = context.get('execution_date')
+    date = context.get('data_interval_start')
     response_pre = ti.xcom_pull(task_ids='get_num_solr_docs_pre')
     ndocs_pre = json.loads(response_pre)["response"]["numFound"]
     response_post = ti.xcom_pull(task_ids='get_num_solr_docs_post')

--- a/doc/catalog-search-oai-harvest-process.md
+++ b/doc/catalog-search-oai-harvest-process.md
@@ -9,12 +9,12 @@ The current catalog OAI harvesting process is broken up into two distinct but li
 Each of these DAGs will harvest independently to a configured collection:
 * `catalog_pre_production_oai_harvest`  harvests:
     * from date set in `CATALOG_PRE_PRODUCTION_HARVEST_FROM_DATE` variable.
-    * until `execution_date` by default.
+    * until `data_interval_start` by default.
     * into the collection set in `CATALOG_PRE_PRODUCTION_SOLR_COLLECTION` variable.
 
 * `catalog_production_oai_harvest_dag` harvests:
     * from date set in `CATALOG_PROD_HARVEST_FROM_DATE` variable.
-    * until `execution_date` by default.
+    * until `data_interval_start` by default.
     * into the collection set in `CATALOG_PRODUCTION_SOLR_COLLECTION` variable
 
 Additional considerations for the OAI Harvest pocess are detailed in the [Deploy to Production](production-solr-collection-swap-process.md#deploy-to-production) section of the [Production Solr Collection Swap Process](production-solr-collection-swap-process.md).


### PR DESCRIPTION
- Updates code to use the data_interval_start macro rather than a python datetime object
- execution_date is deprecated, so use data_interval_start instead