### PR TITLE
Update airflow to 2.8.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-apache-airflow = "==2.7.3"
+aiobotocore = "*"
+apache-airflow = "==2.8.1"
 apache-airflow-providers-slack = "*"
 apache-airflow-providers-amazon = "*"
 apache-airflow-providers-ftp = "*"
@@ -21,6 +22,7 @@ pysftp = "*"
 pylint = "*"
 pytest = "*"
 requests-mock = "*"
+s3fs = "*"
 setuptools = "*"
 sshtunnel = "*"
 sickle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b7e373b8ed08b0ef322132e7d8270551cb7b3100f90e99766e0da188420a78b"
+            "sha256": "641e0c066736e84b5b5ab90f8beb6f5f4aedbc4806df7a8578d76283f66206cd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -17,6 +17,15 @@
     },
     "default": {},
     "develop": {
+        "aiobotocore": {
+            "hashes": [
+                "sha256:487fede588040bfa3a43df945275c28c1c73ca75bf705295adb9fbadd2e89be7",
+                "sha256:6dd7352248e3523019c5a54a395d2b1c31080697fc80a9ad2672de4eec8c7abd"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.11.2"
+        },
         "aiohttp": {
             "hashes": [
                 "sha256:017a21b0df49039c8f46ca0971b3a7fdc1f56741ab1240cb90ca408049766168",
@@ -99,6 +108,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.9.3"
         },
+        "aioitertools": {
+            "hashes": [
+                "sha256:04b95e3dab25b449def24d7df809411c10e62aab0cbe31a50ca4e68748c43394",
+                "sha256:42c68b8dd3a69c2bf7f2233bf7df4bb58b557bca5252ac02ed5187bbc67d6831"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.11.0"
+        },
         "aiosignal": {
             "hashes": [
                 "sha256:54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc",
@@ -133,12 +150,12 @@
         },
         "apache-airflow": {
             "hashes": [
-                "sha256:7f519eed05a047fe347a48ffcab3f78278717c0494c58e42a00f71e54594ebb3",
-                "sha256:b5d3cd9f39e183dd77a6589bcd98a39e31459e792053885b5f584244b5ba7655"
+                "sha256:7443d82b790886c5ec137a8fdb94d672e33e81336713ca7320b4a1bbad443a9c",
+                "sha256:8178b3fd22a8766beb2e2972352f37402994a2ea4356106a6763e05807efaa88"
             ],
             "index": "pypi",
             "markers": "python_version < '3.12' and python_version ~= '3.8'",
-            "version": "==2.7.3"
+            "version": "==2.8.1"
         },
         "apache-airflow-providers-amazon": {
             "hashes": [
@@ -148,6 +165,14 @@
             "index": "pypi",
             "markers": "python_version ~= '3.8'",
             "version": "==8.18.0"
+        },
+        "apache-airflow-providers-common-io": {
+            "hashes": [
+                "sha256:7172620a2370031970df2212a9f694a5ff82240f7e498b8b7dfdbae7e6c882d6",
+                "sha256:a67c6dd3cb419c68fc1a9ed62f0f434426852e15a46c3159f367b3961332955d"
+            ],
+            "markers": "python_version ~= '3.8'",
+            "version": "==1.3.0"
         },
         "apache-airflow-providers-common-sql": {
             "hashes": [
@@ -351,20 +376,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:46432fd506708fec6caec4392d758c6f5b79a376dee67d3284fe8b6bfbafeaf4",
-                "sha256:5c96bed1269f77788780aa2005811dc3a37d4122f08b8e54063a1f4c1b9314a1"
+                "sha256:33a8b6d9136fa7427160edb92d2e50f2035f04e9d63a2d1027349053e12626aa",
+                "sha256:b2f321e20966f021ec800b7f2c01287a3dd04fc5965acdfbaa9c505a24ca45d1"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.45"
+            "version": "==1.34.34"
         },
         "botocore": {
             "hashes": [
-                "sha256:bf4fe24dd00a6262a27573dea1690ea68eb20f939e7086effadf19aa1acb44d1",
-                "sha256:e17874ac708fef295d2ea16bb2570ea0512c920de9f25f796de0d8c778f06a02"
+                "sha256:54093dc97372bb7683f5c61a279aa8240408abf3b2cc494ae82a9a90c1b784b5",
+                "sha256:cd060b0d88ebb2b893f1411c1db7f2ba66cc18e52dcc57ad029564ef5fec437b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.45"
+            "version": "==1.34.34"
         },
         "cachelib": {
             "hashes": [
@@ -373,14 +398,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.9.0"
-        },
-        "cattrs": {
-            "hashes": [
-                "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108",
-                "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==23.2.3"
         },
         "certifi": {
             "hashes": [
@@ -704,11 +721,11 @@
         },
         "flask-appbuilder": {
             "hashes": [
-                "sha256:840480dfd43134bebf78f3c7dc909e324c2689d2d9f27aeb1880a8a25466bc8d",
-                "sha256:8ca9710fa7d2704747d195e11b487d45a571f40559d8399d9d5dfa42ea1f3c78"
+                "sha256:4173c878e56b81c6acac5e3c80c133f4183f43442fd944552bd9f4023f5baceb",
+                "sha256:c0af506e1a68e7ee14f26a16fda829f1a14f8343654c30bdbb1351d23c545df9"
             ],
             "markers": "python_version ~= '3.7'",
-            "version": "==4.3.6"
+            "version": "==4.3.10"
         },
         "flask-babel": {
             "hashes": [
@@ -1085,14 +1102,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.62.0"
-        },
-        "graphviz": {
-            "hashes": [
-                "sha256:587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977",
-                "sha256:8c58f14adaa3b947daf26c19bc1e98c4e0702cdc31cf99153e6f06904d492bf8"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.20.1"
         },
         "greenlet": {
             "hashes": [
@@ -1924,30 +1933,92 @@
         },
         "pendulum": {
             "hashes": [
-                "sha256:0731f0c661a3cb779d398803655494893c9f581f6488048b3fb629c2342b5394",
-                "sha256:1245cd0075a3c6d889f581f6325dd8404aca5884dea7223a5566c38aab94642b",
-                "sha256:29c40a6f2942376185728c9a0347d7c0f07905638c83007e1d262781f1e6953a",
-                "sha256:2d1619a721df661e506eff8db8614016f0720ac171fe80dda1333ee44e684087",
-                "sha256:318f72f62e8e23cd6660dbafe1e346950281a9aed144b5c596b2ddabc1d19739",
-                "sha256:33fb61601083f3eb1d15edeb45274f73c63b3c44a8524703dc143f4212bf3269",
-                "sha256:3481fad1dc3f6f6738bd575a951d3c15d4b4ce7c82dce37cf8ac1483fde6e8b0",
-                "sha256:4c9c689747f39d0d02a9f94fcee737b34a5773803a64a5fdb046ee9cac7442c5",
-                "sha256:7c5ec650cb4bec4c63a89a0242cc8c3cebcec92fcfe937c417ba18277d8560be",
-                "sha256:94b1fc947bfe38579b28e1cccb36f7e28a15e841f30384b5ad6c5e31055c85d7",
-                "sha256:9702069c694306297ed362ce7e3c1ef8404ac8ede39f9b28b7c1a7ad8c3959e3",
-                "sha256:b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207",
-                "sha256:b6c352f4bd32dff1ea7066bd31ad0f71f8d8100b9ff709fb343f3b86cee43efe",
-                "sha256:c501749fdd3d6f9e726086bf0cd4437281ed47e7bca132ddb522f86a1645d360",
-                "sha256:c807a578a532eeb226150d5006f156632df2cc8c5693d778324b43ff8c515dd0",
-                "sha256:db0a40d8bcd27b4fb46676e8eb3c732c67a5a5e6bfab8927028224fbced0b40b",
-                "sha256:de42ea3e2943171a9e95141f2eecf972480636e8e484ccffaf1e833929e9e052",
-                "sha256:e95d329384717c7bf627bf27e204bc3b15c8238fa8d9d9781d93712776c14002",
-                "sha256:f5e236e7730cab1644e1b87aca3d2ff3e375a608542e90fe25685dae46310116",
-                "sha256:f888f2d2909a414680a29ae74d0592758f2b9fcdee3549887779cd4055e975db",
-                "sha256:fb53ffa0085002ddd43b6ca61a7b34f2d4d7c3ed66f931fe599e1a531b42af9b"
+                "sha256:04a1094a5aa1daa34a6b57c865b25f691848c61583fb22722a4df5699f6bf74c",
+                "sha256:0a15b90129765b705eb2039062a6daf4d22c4e28d1a54fa260892e8c3ae6e157",
+                "sha256:0a78ad3635d609ceb1e97d6aedef6a6a6f93433ddb2312888e668365908c7120",
+                "sha256:0c2308af4033fa534f089595bcd40a95a39988ce4059ccd3dc6acb9ef14ca44a",
+                "sha256:0c717eab1b6d898c00a3e0fa7781d615b5c5136bbd40abe82be100bb06df7a56",
+                "sha256:138afa9c373ee450ede206db5a5e9004fd3011b3c6bbe1e57015395cd076a09f",
+                "sha256:17fe4b2c844bbf5f0ece69cfd959fa02957c61317b2161763950d88fed8e13b9",
+                "sha256:1a3604e9fbc06b788041b2a8b78f75c243021e0f512447806a6d37ee5214905d",
+                "sha256:1c134ba2f0571d0b68b83f6972e2307a55a5a849e7dac8505c715c531d2a8795",
+                "sha256:2165a8f33cb15e06c67070b8afc87a62b85c5a273e3aaa6bc9d15c93a4920d6f",
+                "sha256:22e7944ffc1f0099a79ff468ee9630c73f8c7835cd76fdb57ef7320e6a409df4",
+                "sha256:235d64e87946d8f95c796af34818c76e0f88c94d624c268693c85b723b698aa9",
+                "sha256:28f49d8d1e32aae9c284a90b6bb3873eee15ec6e1d9042edd611b22a94ac462f",
+                "sha256:2cf9e53ef11668e07f73190c805dbdf07a1939c3298b78d5a9203a86775d1bfd",
+                "sha256:2e169cc2ca419517f397811bbe4589cf3cd13fca6dc38bb352ba15ea90739ebb",
+                "sha256:314c4038dc5e6a52991570f50edb2f08c339debdf8cea68ac355b32c4174e820",
+                "sha256:3725245c0352c95d6ca297193192020d1b0c0f83d5ee6bb09964edc2b5a2d508",
+                "sha256:385680812e7e18af200bb9b4a49777418c32422d05ad5a8eb85144c4a285907b",
+                "sha256:3b1f74d1e6ffe5d01d6023870e2ce5c2191486928823196f8575dcc786e107b1",
+                "sha256:3d897eb50883cc58d9b92f6405245f84b9286cd2de6e8694cb9ea5cb15195a32",
+                "sha256:3ddd1d66d1a714ce43acfe337190be055cdc221d911fc886d5a3aae28e14b76d",
+                "sha256:409e64e41418c49f973d43a28afe5df1df4f1dd87c41c7c90f1a63f61ae0f1f7",
+                "sha256:4386bffeca23c4b69ad50a36211f75b35a4deb6210bdca112ac3043deb7e494a",
+                "sha256:440215347b11914ae707981b9a57ab9c7b6983ab0babde07063c6ee75c0dc6e7",
+                "sha256:4b2c5675769fb6d4c11238132962939b960fcb365436b6d623c5864287faa319",
+                "sha256:4e8e36a8130819d97a479a0e7bf379b66b3b1b520e5dc46bd7eb14634338df8c",
+                "sha256:597e66e63cbd68dd6d58ac46cb7a92363d2088d37ccde2dae4332ef23e95cd00",
+                "sha256:5acb1d386337415f74f4d1955c4ce8d0201978c162927d07df8eb0692b2d8533",
+                "sha256:5b0ec85b9045bd49dd3a3493a5e7ddfd31c36a2a60da387c419fa04abcaecb23",
+                "sha256:5d034998dea404ec31fae27af6b22cff1708f830a1ed7353be4d1019bb9f584e",
+                "sha256:5ebc65ea033ef0281368217fbf59f5cb05b338ac4dd23d60959c7afcd79a60a0",
+                "sha256:60fb6f415fea93a11c52578eaa10594568a6716602be8430b167eb0d730f3332",
+                "sha256:660434a6fcf6303c4efd36713ca9212c753140107ee169a3fc6c49c4711c2a05",
+                "sha256:6a881d9c2a7f85bc9adafcfe671df5207f51f5715ae61f5d838b77a1356e8b7b",
+                "sha256:6c035f03a3e565ed132927e2c1b691de0dbf4eb53b02a5a3c5a97e1a64e17bec",
+                "sha256:6c58227ac260d5b01fc1025176d7b31858c9f62595737f350d22124a9a3ad82d",
+                "sha256:729e9f93756a2cdfa77d0fc82068346e9731c7e884097160603872686e570f07",
+                "sha256:773c3bc4ddda2dda9f1b9d51fe06762f9200f3293d75c4660c19b2614b991d83",
+                "sha256:77d8839e20f54706aed425bec82a83b4aec74db07f26acd039905d1237a5e1d4",
+                "sha256:78f8f4e7efe5066aca24a7a57511b9c2119f5c2b5eb81c46ff9222ce11e0a7a5",
+                "sha256:7dc843253ac373358ffc0711960e2dd5b94ab67530a3e204d85c6e8cb2c5fa10",
+                "sha256:822172853d7a9cf6da95d7b66a16c7160cb99ae6df55d44373888181d7a06edc",
+                "sha256:825799c6b66e3734227756fa746cc34b3549c48693325b8b9f823cb7d21b19ac",
+                "sha256:826d6e258052715f64d05ae0fc9040c0151e6a87aae7c109ba9a0ed930ce4000",
+                "sha256:83a44e8b40655d0ba565a5c3d1365d27e3e6778ae2a05b69124db9e471255c4a",
+                "sha256:83d9031f39c6da9677164241fd0d37fbfc9dc8ade7043b5d6d62f56e81af8ad2",
+                "sha256:840de1b49cf1ec54c225a2a6f4f0784d50bd47f68e41dc005b7f67c7d5b5f3ae",
+                "sha256:860aa9b8a888e5913bd70d819306749e5eb488e6b99cd6c47beb701b22bdecf5",
+                "sha256:8af95e03e066826f0f4c65811cbee1b3123d4a45a1c3a2b4fc23c4b0dff893b5",
+                "sha256:92c307ae7accebd06cbae4729f0ba9fa724df5f7d91a0964b1b972a22baa482b",
+                "sha256:99a0f8172e19f3f0c0e4ace0ad1595134d5243cf75985dc2233e8f9e8de263ca",
+                "sha256:9a59637cdb8462bdf2dbcb9d389518c0263799189d773ad5c11db6b13064fa79",
+                "sha256:9eec91cd87c59fb32ec49eb722f375bd58f4be790cae11c1b70fac3ee4f00da0",
+                "sha256:a38ad2121c5ec7c4c190c7334e789c3b4624798859156b138fcc4d92295835dc",
+                "sha256:a5346d08f3f4a6e9e672187faa179c7bf9227897081d7121866358af369f44f9",
+                "sha256:a6fc26907eb5fb8cc6188cc620bc2075a6c534d981a2f045daa5f79dfe50d512",
+                "sha256:a789e12fbdefaffb7b8ac67f9d8f22ba17a3050ceaaa635cd1cc4645773a4b1e",
+                "sha256:a90d4d504e82ad236afac9adca4d6a19e4865f717034fc69bafb112c320dcc8f",
+                "sha256:ac65eeec2250d03106b5e81284ad47f0d417ca299a45e89ccc69e36130ca8bc7",
+                "sha256:ad5e65b874b5e56bd942546ea7ba9dd1d6a25121db1c517700f1c9de91b28518",
+                "sha256:ad769e98dc07972e24afe0cff8d365cb6f0ebc7e65620aa1976fcfbcadc4c6f3",
+                "sha256:afde30e8146292b059020fbc8b6f8fd4a60ae7c5e6f0afef937bbb24880bdf01",
+                "sha256:b11aceea5b20b4b5382962b321dbc354af0defe35daa84e9ff3aae3c230df694",
+                "sha256:b30a137e9e0d1f751e60e67d11fc67781a572db76b2296f7b4d44554761049d6",
+                "sha256:b69f6b4dbcb86f2c2fe696ba991e67347bcf87fe601362a1aba6431454b46bde",
+                "sha256:bb8f6d7acd67a67d6fedd361ad2958ff0539445ef51cbe8cd288db4306503cd0",
+                "sha256:c95984037987f4a457bb760455d9ca80467be792236b69d0084f228a8ada0162",
+                "sha256:d29c6e578fe0f893766c0d286adbf0b3c726a4e2341eba0917ec79c50274ec16",
+                "sha256:d2aae97087872ef152a0c40e06100b3665d8cb86b59bc8471ca7c26132fccd0f",
+                "sha256:d4cdecde90aec2d67cebe4042fd2a87a4441cc02152ed7ed8fb3ebb110b94ec4",
+                "sha256:d4e2512f4e1a4670284a153b214db9719eb5d14ac55ada5b76cbdb8c5c00399d",
+                "sha256:d7762d2076b9b1cb718a6631ad6c16c23fc3fac76cbb8c454e81e80be98daa34",
+                "sha256:d9fef18ab0386ef6a9ac7bad7e43ded42c83ff7ad412f950633854f90d59afa8",
+                "sha256:dc00f8110db6898360c53c812872662e077eaf9c75515d53ecc65d886eec209a",
+                "sha256:deaba8e16dbfcb3d7a6b5fabdd5a38b7c982809567479987b9c89572df62e027",
+                "sha256:dee9e5a48c6999dc1106eb7eea3e3a50e98a50651b72c08a87ee2154e544b33e",
+                "sha256:dfbcf1661d7146d7698da4b86e7f04814221081e9fe154183e34f4c5f5fa3bf8",
+                "sha256:e586acc0b450cd21cbf0db6bae386237011b75260a3adceddc4be15334689a9a",
+                "sha256:f17c3084a4524ebefd9255513692f7e7360e23c8853dc6f10c64cc184e1217ab",
+                "sha256:fa30af36bd8e50686846bdace37cf6707bdd044e5cb6e1109acbad3277232e04",
+                "sha256:fb551b9b5e6059377889d2d878d940fd0bbb80ae4810543db18e6f77b02c5ef6",
+                "sha256:fd69b15374bef7e4b4440612915315cc42e8575fcda2a3d7586a0d88192d0c88",
+                "sha256:fde4d0b2024b9785f66b7f30ed59281bd60d63d9213cda0eb0910ead777f6d37"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.0"
         },
         "pexpect": {
             "hashes": [
@@ -2235,14 +2306,6 @@
             ],
             "version": "==2024.1"
         },
-        "pytzdata": {
-            "hashes": [
-                "sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540",
-                "sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2020.1"
-        },
         "pyyaml": {
             "hashes": [
                 "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
@@ -2475,6 +2538,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.18.0"
+        },
+        "s3fs": {
+            "hashes": [
+                "sha256:c140de37175c157cb662aa6ad7423365df732ac5f10ef5bf7b76078c6333a942",
+                "sha256:f8064f522ad088b56b043047c825734847c0269df19f2613c956d4c20de15b62"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2024.2.0"
         },
         "s3transfer": {
             "hashes": [
@@ -2759,6 +2831,68 @@
             ],
             "version": "==1.3"
         },
+        "time-machine": {
+            "hashes": [
+                "sha256:02b33a8c19768c94f7ffd6aa6f9f64818e88afce23250016b28583929d20fb12",
+                "sha256:0c9829b2edfcf6b5d72a6ff330d4380f36a937088314c675531b43d3423dd8af",
+                "sha256:0cc116056a8a2a917a4eec85661dfadd411e0d8faae604ef6a0e19fe5cd57ef1",
+                "sha256:0db97f92be3efe0ac62fd3f933c91a78438cef13f283b6dfc2ee11123bfd7d8a",
+                "sha256:12eed2e9171c85b703d75c985dab2ecad4fe7025b7d2f842596fce1576238ece",
+                "sha256:1812e48c6c58707db9988445a219a908a710ea065b2cc808d9a50636291f27d4",
+                "sha256:19a3b10161c91ca8e0fd79348665cca711fd2eac6ce336ff9e6b447783817f93",
+                "sha256:1a22be4df364f49a507af4ac9ea38108a0105f39da3f9c60dce62d6c6ea4ccdc",
+                "sha256:1ac8ff145c63cd0dcfd9590fe694b5269aacbc130298dc7209b095d101f8cdde",
+                "sha256:20205422fcf2caf9a7488394587df86e5b54fdb315c1152094fbb63eec4e9304",
+                "sha256:21bef5854d49b62e2c33848b5c3e8acf22a3b46af803ef6ff19529949cb7cf9f",
+                "sha256:2bd4169b808745d219a69094b3cb86006938d45e7293249694e6b7366225a186",
+                "sha256:2dc76ee55a7d915a55960a726ceaca7b9097f67e4b4e681ef89871bcf98f00be",
+                "sha256:32b71e50b07f86916ac04bd1eefc2bd2c93706b81393748b08394509ee6585dc",
+                "sha256:34dcdbbd25c1e124e17fe58050452960fd16a11f9d3476aaa87260e28ecca0fd",
+                "sha256:3a7a0a49ce50d9c306c4343a7d6a3baa11092d4399a4af4355c615ccc321a9d3",
+                "sha256:3c87856105dcb25b5bbff031d99f06ef4d1c8380d096222e1bc63b496b5258e6",
+                "sha256:42ef5349135626ad6cd889a0a81400137e5c6928502b0817ea9e90bb10702000",
+                "sha256:4ca20f85a973a4ca8b00cf466cd72c27ccc72372549b138fd48d7e70e5a190ab",
+                "sha256:4e3a2611f8788608ebbcb060a5e36b45911bc3b8adc421b1dc29d2c81786ce4d",
+                "sha256:4f2ae8d0e359b216b695f1e7e7256f208c390db0480601a439c5dd1e1e4e16ce",
+                "sha256:5aee23cd046abf9caeddc982113e81ba9097a01f3972e9560f5ed64e3495f66d",
+                "sha256:5c6245db573863b335d9ca64b3230f623caf0988594ae554c0c794e7f80e3e66",
+                "sha256:5f87787d562e42bf1006a87eb689814105b98c4d5545874a281280d0f8b9a2d9",
+                "sha256:5fe3fda5fa73fec74278912e438fce1612a79c36fd0cc323ea3dc2d5ce629f31",
+                "sha256:62fd14a80b8b71726e07018628daaee0a2e00937625083f96f69ed6b8e3304c0",
+                "sha256:66fb3877014dca0b9286b0f06fa74062357bd23f2d9d102d10e31e0f8fa9b324",
+                "sha256:679cbf9b15bfde1654cf48124128d3fbe52f821fa158a98fcee5fe7e05db1917",
+                "sha256:67fa45cd813821e4f5bec0ac0820869e8e37430b15509d3f5fad74ba34b53852",
+                "sha256:685d98593f13649ad5e7ce3e58efe689feca1badcf618ba397d3ab877ee59326",
+                "sha256:6c16d90a597a8c2d3ce22d6be2eb3e3f14786974c11b01886e51b3cf0d5edaf7",
+                "sha256:71acbc1febbe87532c7355eca3308c073d6e502ee4ce272b5028967847c8e063",
+                "sha256:7558622a62243be866a7e7c41da48eacd82c874b015ecf67d18ebf65ca3f7436",
+                "sha256:7693704c0f2f6b9beed912ff609781edf5fcf5d63aff30c92be4093e09d94b8e",
+                "sha256:88601de1da06c7cab3d5ed3d5c3801ef683366e769e829e96383fdab6ae2fe42",
+                "sha256:8d526cdcaca06a496877cfe61cc6608df2c3a6fce210e076761964ebac7f77cc",
+                "sha256:918f8389de29b4f41317d121f1150176fae2cdb5fa41f68b2aee0b9dc88df5c3",
+                "sha256:924377d398b1c48e519ad86a71903f9f36117f69e68242c99fb762a2465f5ad2",
+                "sha256:9f128db8997c3339f04f7f3946dd9bb2a83d15e0a40d35529774da1e9e501511",
+                "sha256:9fad549521c4c13bdb1e889b2855a86ec835780d534ffd8f091c2647863243be",
+                "sha256:a26bdf3462d5f12a4c1009fdbe54366c6ef22c7b6f6808705b51dedaaeba8296",
+                "sha256:ab04cf4e56e1ee65bee2adaa26a04695e92eb1ed1ccc65fbdafd0d114399595a",
+                "sha256:b0c8f24ae611a58782773af34dd356f1f26756272c04be2be7ea73b47e5da37d",
+                "sha256:bdfe4a7f033e6783c3e9a7f8d8fc0b115367330762e00a03ff35fedf663994f3",
+                "sha256:c23b2408e3adcedec84ea1131e238f0124a5bc0e491f60d1137ad7239b37c01a",
+                "sha256:ccbce292380ebf63fb9a52e6b03d91677f6a003e0c11f77473efe3913a75f289",
+                "sha256:cfef4ebfb4f055ce3ebc7b6c1c4d0dbfcffdca0e783ad8c6986c992915a57ed3",
+                "sha256:d4a2d3db2c3b8e519d5ef436cd405abd33542a7b7761fb05ef5a5f782a8ce0b1",
+                "sha256:dabb3b155819811b4602f7e9be936e2024e20dc99a90f103e36b45768badf9c3",
+                "sha256:de01f33aa53da37530ad97dcd17e9affa25a8df4ab822506bb08101bab0c2673",
+                "sha256:dec0ec2135a4e2a59623e40c31d6e8a8ae73305ade2634380e4263d815855750",
+                "sha256:e433827eccd6700a34a2ab28fd9361ff6e4d4923f718d2d1dac6d1dcd9d54da6",
+                "sha256:e58d82fe0e59d6e096ada3281d647a2e7420f7da5453b433b43880e1c2e8e0c5",
+                "sha256:e9935aff447f5400a2665ab10ed2da972591713080e1befe1bb8954e7c0c7806",
+                "sha256:e9a9d150e098be3daee5c9f10859ab1bd14a61abebaed86e6d71f7f18c05b9d7",
+                "sha256:f5fa9610f7e73fff42806a2ed8b06d862aa59ce4d178a52181771d6939c3e237"
+            ],
+            "markers": "implementation_name != 'pypy'",
+            "version": "==2.13.0"
+        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
@@ -2812,6 +2946,14 @@
                 "sha256:018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc"
             ],
             "version": "==0.14.1"
+        },
+        "universal-pathlib": {
+            "hashes": [
+                "sha256:bb14881f1c6c025c654a658c253b4cf89e8238dff6d3c847aa5723899227f85e",
+                "sha256:fda2f484d875c26079771f94acfef58647eed80efce75f0bf8824373b432e802"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.2.1"
         },
         "urllib3": {
             "hashes": [
@@ -2915,11 +3057,11 @@
         },
         "wtforms": {
             "hashes": [
-                "sha256:6b351bbb12dd58af57ffef05bc78425d08d1914e0fd68ee14143b7ade023c5bc",
-                "sha256:837f2f0e0ca79481b92884962b914eba4e72b7a2daaf1f939c890ed0124b834b"
+                "sha256:bf831c042829c8cdbad74c27575098d541d039b1faa74c771545ecac916f2c07",
+                "sha256:f8d76180d7239c94c6322f7990ae1216dae3659b7aa1cee94b6318bdffb474b9"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.0.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.1.2"
         },
         "xmltodict": {
             "hashes": [

--- a/tests/operators/solr_api/delete_collection_test.py
+++ b/tests/operators/solr_api/delete_collection_test.py
@@ -45,8 +45,8 @@ class DeleteCollectionTest(unittest.TestCase):
                 name='foo',
                 solr_conn_id='solr_conn_id').execute()
 
-        expected_log_message = 'INFO:airflow.task.operators:Attempting to process foo item.'
-        response_log = 'INFO:airflow.task.operators:{"status":{"status": 200}}'
+        expected_log_message = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollection:Attempting to process foo item.'
+        response_log = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollection:{"status":{"status": 200}}'
 
         self.assertIn(expected_log_message, log.output)
         self.assertIn(response_log, log.output)
@@ -68,7 +68,7 @@ class DeleteCollectionTest(unittest.TestCase):
                 solr_conn_id='solr_conn_id')
             task.execute()
             self.assertEqual(task.processed_items, [{'name': 'foo', 'status': 'OK'}])
-        msg = 'INFO:airflow.task.operators:{"status":{"status": 200}}'
+        msg = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollection:{"status":{"status": 200}}'
         self.assertIn(msg, log.output)
 
     @requests_mock.mock()
@@ -149,7 +149,7 @@ class DeleteCollectionTest(unittest.TestCase):
             self.assertEqual(task.processed_items,
                              [{'name': 'foo', 'status': 'SKIPPED', 'reason': 'skip_included'}])
 
-        skip_log_message = "INFO:airflow.task.operators:Skipping processing foo because it is included in ['foo']"
+        skip_log_message = "INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollection:Skipping processing foo because it is included in ['foo']"
         self.assertIn(skip_log_message, log.output)
 
         log_message = 'INFO:airflow.task.operators:Attempting to delete foo collection.'
@@ -169,7 +169,7 @@ class DeleteCollectionTest(unittest.TestCase):
             self.assertEqual(task.processed_items,
                              [{'name': 'foo', 'status': 'SKIPPED', 'reason': 'skip_matching'}])
 
-        skip_log_message = 'INFO:airflow.task.operators:Skipping processing foo because it matches "fo.*"'
+        skip_log_message = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollection:Skipping processing foo because it matches "fo.*"'
         self.assertIn(skip_log_message, log.output)
 
         log_message = 'INFO:airflow.task.operators:Attempting to delete foo collection.'
@@ -214,16 +214,16 @@ class DeleteCollectionBatchTest(unittest.TestCase):
                 skip_from_last=0,
                 solr_conn_id='solr_conn_id').execute()
 
-        log_message_foo = 'INFO:airflow.task.operators:Attempting to process foo item.'
+        log_message_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process foo item.'
         self.assertIn(log_message_foo, log.output)
 
-        response_log_foo = 'INFO:airflow.task.operators:{ "collection": "foo" }'
+        response_log_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "foo" }'
         self.assertIn(response_log_foo, log.output)
 
-        log_message_bar = 'INFO:airflow.task.operators:Attempting to process bar item.'
+        log_message_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process bar item.'
         self.assertIn(log_message_bar, log.output)
 
-        response_log_bar = 'INFO:airflow.task.operators:{ "collection": "bar" }'
+        response_log_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "bar" }'
         self.assertIn(response_log_bar, log.output)
 
     @requests_mock.mock()
@@ -244,16 +244,16 @@ class DeleteCollectionBatchTest(unittest.TestCase):
                 solr_conn_id='solr_conn_id',
                 skip_included=['bar']).execute()
 
-        log_message_foo = 'INFO:airflow.task.operators:Attempting to process foo item.'
+        log_message_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process foo item.'
         self.assertIn(log_message_foo, log.output)
 
-        response_log_foo = 'INFO:airflow.task.operators:{ "collection": "foo" }'
+        response_log_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "foo" }'
         self.assertIn(response_log_foo, log.output)
 
-        log_message_bar = 'INFO:airflow.task.operators:Attempting to process bar item.'
+        log_message_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process bar item.'
         self.assertNotIn(log_message_bar, log.output)
 
-        response_log_bar = 'INFO:airflow.task.operators:{ "collection": "bar" }'
+        response_log_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "bar" }'
         self.assertNotIn(response_log_bar, log.output)
 
     @requests_mock.mock()
@@ -275,19 +275,19 @@ class DeleteCollectionBatchTest(unittest.TestCase):
                 solr_conn_id='solr_conn_id',
                 skip_matching='ba.*').execute()
 
-        log_message_foo = 'INFO:airflow.task.operators:Attempting to process foo item.'
+        log_message_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process foo item.'
         self.assertIn(log_message_foo, log.output)
 
-        response_log_foo = 'INFO:airflow.task.operators:{ "collection": "foo" }'
+        response_log_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "foo" }'
         self.assertIn(response_log_foo, log.output)
 
-        log_message_bar = 'INFO:airflow.task.operators:Attempting to process bar item.'
+        log_message_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process bar item.'
         self.assertNotIn(log_message_bar, log.output)
 
-        response_log_bar = 'INFO:airflow.task.operators:{ "collection": "bar" }'
+        response_log_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "bar" }'
         self.assertNotIn(response_log_bar, log.output)
 
-        skip_log_message = 'INFO:airflow.task.operators:Skipping processing bar because it matches "ba.*"'
+        skip_log_message = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Skipping processing bar because it matches "ba.*"'
         self.assertIn(skip_log_message, log.output)
 
     @requests_mock.mock()
@@ -311,19 +311,19 @@ class DeleteCollectionBatchTest(unittest.TestCase):
             self.assertIn({'name': 'bar', 'status': 'SKIPPED', 'reason': 'skip_from_last'},
                           task.processed_items)
 
-        log_message_foo = 'INFO:airflow.task.operators:Attempting to process foo item.'
+        log_message_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process foo item.'
         self.assertIn(log_message_foo, log.output)
 
-        response_log_foo = 'INFO:airflow.task.operators:{ "collection": "foo" }'
+        response_log_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "foo" }'
         self.assertIn(response_log_foo, log.output)
 
-        log_message_bar = 'INFO:airflow.task.operators:Attempting to process bar item.'
+        log_message_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Attempting to process bar item.'
         self.assertNotIn(log_message_bar, log.output)
 
-        response_log_bar = 'INFO:airflow.task.operators:{ "collection": "bar" }'
+        response_log_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:{ "collection": "bar" }'
         self.assertNotIn(response_log_bar, log.output)
 
-        skip_log_message = 'INFO:airflow.task.operators:Skipping the last 1 items: bar'
+        skip_log_message = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionBatch:Skipping the last 1 items: bar'
         self.assertIn(skip_log_message, log.output)
 
 class DeleteCollectionListVariableTest(unittest.TestCase):
@@ -360,16 +360,16 @@ class DeleteCollectionListVariableTest(unittest.TestCase):
                 skip_from_last=0,
                 solr_conn_id='solr_conn_id').execute()
 
-        log_message_foo = 'INFO:airflow.task.operators:Attempting to process foo item.'
+        log_message_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionListVariable:Attempting to process foo item.'
         self.assertIn(log_message_foo, log.output)
 
-        response_log_foo = 'INFO:airflow.task.operators:{ "collection": "foo" }'
+        response_log_foo = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionListVariable:{ "collection": "foo" }'
         self.assertIn(response_log_foo, log.output)
 
-        log_message_bar = 'INFO:airflow.task.operators:Attempting to process bar item.'
+        log_message_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionListVariable:Attempting to process bar item.'
         self.assertIn(log_message_bar, log.output)
 
-        response_log_bar = 'INFO:airflow.task.operators:{ "collection": "bar" }'
+        response_log_bar = 'INFO:airflow.task.operators.cob_datapipeline.operators.solr_api.delete_collection.DeleteCollectionListVariable:{ "collection": "bar" }'
         self.assertIn(response_log_bar, log.output)
 
     def test_reset_list_variable_does_not_exist(self):


### PR DESCRIPTION
The failures in the tests were all related to the expected log output changing.  It doesn't seem that the actual methods had any breaking changes.