### PR TITLE
BL-1897: Allow production oai harvest to handle no records.

### DIFF
--- a/cob_datapipeline/catalog_preproduction_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_preproduction_oai_harvest_dag.py
@@ -190,6 +190,7 @@ INDEX_UPDATES_OAI_MARC = BashOperator(
         "ALMAOAI_LAST_HARVEST_FROM_DATE": CATALOG_LAST_HARVEST_FROM_DATE,
         "COMMAND": "ingest",
     }},
+    trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
 
@@ -209,6 +210,7 @@ INDEX_DELETES_OAI_MARC = BashOperator(
         "SOLR_URL": tasks.get_solr_url(SOLR_WRITER, COLLECTION),
         "COMMAND": "delete --suppress",
     }},
+    trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
 
@@ -217,6 +219,7 @@ SOLR_COMMIT = HttpOperator(
     method='GET',
     http_conn_id=SOLR_WRITER.conn_id,
     endpoint= '/solr/' + COLLECTION + '/update?commit=true',
+    trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
 
@@ -252,6 +255,7 @@ UPDATES_AND_DELETES_BRANCH = EmptyOperator(task_id = 'updates_and_deletes_branch
 SUCCESS = EmptyOperator(
         task_id = 'success',
         on_success_callback=[slackpostonsuccess],
+        trigger_rule="none_failed_min_one_success",
         dag=DAG)
 
 # SET UP TASK DEPENDENCIES

--- a/cob_datapipeline/catalog_preproduction_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_preproduction_oai_harvest_dag.py
@@ -239,25 +239,9 @@ UPDATE_DATE_VARIABLES = PythonOperator(
     dag=DAG
 )
 
-def choose_indexing_branch(**kwargs):
-    ti = kwargs['ti']
-    harvest_data = ti.xcom_pull(task_ids="oai_harvest")
-    updates = harvest_data.get("updated", 0) > 0
-    deletes = harvest_data.get("deleted", 0) > 0
-
-    if updates and deletes:
-        return "updates_and_deletes_branch"
-    elif updates:
-        return "updates_only_branch"
-    elif deletes:
-        return "deletes_only_branch"
-    else:
-        return "no_updates_no_deletes_branch"
-
-
 CHOOSE_INDEXING_BRANCH = BranchPythonOperator(
-        task_id='choose_indexing_branch',
-        python_callable=choose_indexing_branch,
+        task_id="choose_indexing_branch",
+        python_callable=helpers.choose_indexing_branch,
         provide_context=True,
         dag=DAG)
 
@@ -283,29 +267,30 @@ CHOOSE_INDEXING_BRANCH.set_upstream(OAI_HARVEST)
  >> UPDATES_ONLY_BRANCH
  >> INDEX_UPDATES_OAI_MARC
  >> SOLR_COMMIT
->> GET_NUM_SOLR_DOCS_POST
->> UPDATE_DATE_VARIABLES)
+ >> GET_NUM_SOLR_DOCS_POST
+ >> UPDATE_DATE_VARIABLES
+ >> SUCCESS)
 
 # deletes_only
 (CHOOSE_INDEXING_BRANCH
->> DELETES_ONLY_BRANCH
->> INDEX_DELETES_OAI_MARC
->> SOLR_COMMIT
->> GET_NUM_SOLR_DOCS_POST
->> UPDATE_DATE_VARIABLES
->> SUCCESS)
+ >> DELETES_ONLY_BRANCH
+ >> INDEX_DELETES_OAI_MARC
+ >> SOLR_COMMIT
+ >> GET_NUM_SOLR_DOCS_POST
+ >> UPDATE_DATE_VARIABLES
+ >> SUCCESS)
 
 # updates_and_deletes
 (CHOOSE_INDEXING_BRANCH
->> UPDATES_AND_DELETES_BRANCH
->> INDEX_UPDATES_OAI_MARC
->> INDEX_DELETES_OAI_MARC
->> SOLR_COMMIT
->> GET_NUM_SOLR_DOCS_POST
->> UPDATE_DATE_VARIABLES
->> SUCCESS)
+ >> UPDATES_AND_DELETES_BRANCH
+ >> INDEX_UPDATES_OAI_MARC
+ >> INDEX_DELETES_OAI_MARC
+ >> SOLR_COMMIT
+ >> GET_NUM_SOLR_DOCS_POST
+ >> UPDATE_DATE_VARIABLES
+ >> SUCCESS)
 
 # no_updates_no_deletes
 (CHOOSE_INDEXING_BRANCH
->> NO_UPDATES_NO_DELETES_BRANCH
->> SUCCESS)
+ >> NO_UPDATES_NO_DELETES_BRANCH
+ >> SUCCESS)

--- a/cob_datapipeline/catalog_production_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_production_oai_harvest_dag.py
@@ -11,7 +11,9 @@ from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
 from airflow.hooks.base import BaseHook
 from airflow.models import Variable
 from airflow.operators.bash import BashOperator
-from airflow.operators.python  import PythonOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python  import PythonOperator, BranchPythonOperator
+from cob_datapipeline import helpers
 from cob_datapipeline.notifiers import send_collection_notification
 from cob_datapipeline.tasks.xml_parse import prepare_oai_boundwiths, update_variables
 from cob_datapipeline.tasks.task_solr_get_num_docs import task_solrgetnumdocs
@@ -229,24 +231,71 @@ UPDATE_DATE_VARIABLES = PythonOperator(
     dag=DAG
 )
 
+CHOOSE_INDEXING_BRANCH = BranchPythonOperator(
+        task_id="choose_indexing_branch",
+        python_callable=helpers.choose_indexing_branch,
+        provide_context=True,
+        dag=DAG)
+
+NO_UPDATES_NO_DELETES_BRANCH = EmptyOperator(task_id = 'no_updates_no_deletes_branch', dag=DAG)
+UPDATES_ONLY_BRANCH = EmptyOperator(task_id = 'updates_only_branch', dag=DAG)
+DELETES_ONLY_BRANCH = EmptyOperator(task_id = 'deletes_only_branch', dag=DAG)
+UPDATES_AND_DELETES_BRANCH = EmptyOperator(task_id = 'updates_and_deletes_branch', dag=DAG)
+
 CLEAR_CATALOG_CACHE = HttpOperator(
     task_id="clear_catalog_cache",
     method="DELETE",
     http_conn_id="http_tul_cob",
     endpoint="clear_caches",
     headers={"Content-Type": "application/json"},
-    on_success_callback=[slackpostonsuccess],
     dag=DAG
 )
+
+SUCCESS = EmptyOperator(
+        task_id = 'success',
+        on_success_callback=[slackpostonsuccess],
+        dag=DAG)
+
 
 # SET UP TASK DEPENDENCIES
 BW_OAI_HARVEST.set_upstream(GET_NUM_SOLR_DOCS_PRE)
 LIST_CATALOG_BW_S3_DATA.set_upstream(BW_OAI_HARVEST)
 PREPARE_BOUNDWITHS.set_upstream(LIST_CATALOG_BW_S3_DATA)
 OAI_HARVEST.set_upstream(PREPARE_BOUNDWITHS)
-INDEX_UPDATES_OAI_MARC.set_upstream(OAI_HARVEST)
-INDEX_DELETES_OAI_MARC.set_upstream(INDEX_UPDATES_OAI_MARC)
-SOLR_COMMIT.set_upstream(INDEX_DELETES_OAI_MARC)
-GET_NUM_SOLR_DOCS_POST.set_upstream(SOLR_COMMIT)
-UPDATE_DATE_VARIABLES.set_upstream(GET_NUM_SOLR_DOCS_POST)
-CLEAR_CATALOG_CACHE.set_upstream(UPDATE_DATE_VARIABLES)
+CHOOSE_INDEXING_BRANCH.set_upstream(OAI_HARVEST)
+
+# updates_only
+(CHOOSE_INDEXING_BRANCH
+ >> UPDATES_ONLY_BRANCH
+ >> INDEX_UPDATES_OAI_MARC
+ >> SOLR_COMMIT
+ >> GET_NUM_SOLR_DOCS_POST
+ >> UPDATE_DATE_VARIABLES
+ >> CLEAR_CATALOG_CACHE
+ >> SUCCESS)
+
+# deletes_only
+(CHOOSE_INDEXING_BRANCH
+ >> DELETES_ONLY_BRANCH
+ >> INDEX_DELETES_OAI_MARC
+ >> SOLR_COMMIT
+ >> GET_NUM_SOLR_DOCS_POST
+ >> UPDATE_DATE_VARIABLES
+ >> CLEAR_CATALOG_CACHE
+ >> SUCCESS)
+
+# updates_and_deletes
+(CHOOSE_INDEXING_BRANCH
+ >> UPDATES_AND_DELETES_BRANCH
+ >> INDEX_UPDATES_OAI_MARC
+ >> INDEX_DELETES_OAI_MARC
+ >> SOLR_COMMIT
+ >> GET_NUM_SOLR_DOCS_POST
+ >> UPDATE_DATE_VARIABLES
+ >> CLEAR_CATALOG_CACHE
+ >> SUCCESS)
+
+# no_updates_no_deletes
+(CHOOSE_INDEXING_BRANCH
+ >> NO_UPDATES_NO_DELETES_BRANCH
+ >> SUCCESS)

--- a/cob_datapipeline/catalog_production_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_production_oai_harvest_dag.py
@@ -182,6 +182,7 @@ INDEX_UPDATES_OAI_MARC = BashOperator(
         "ALMAOAI_LAST_HARVEST_FROM_DATE": CATALOG_LAST_HARVEST_FROM_DATE,
         "COMMAND": "ingest",
     }},
+    trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
 
@@ -201,6 +202,7 @@ INDEX_DELETES_OAI_MARC = BashOperator(
         "SOLR_URL": tasks.get_solr_url(SOLR_WRITER, COLLECTION),
         "COMMAND": "delete --suppress",
     }},
+    trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
 
@@ -209,6 +211,7 @@ SOLR_COMMIT = HttpOperator(
     method='GET',
     http_conn_id=SOLR_WRITER.conn_id,
     endpoint= '/solr/' + COLLECTION + '/update?commit=true',
+    trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
 
@@ -254,6 +257,7 @@ CLEAR_CATALOG_CACHE = HttpOperator(
 SUCCESS = EmptyOperator(
         task_id = 'success',
         on_success_callback=[slackpostonsuccess],
+        trigger_rule="none_failed_min_one_success",
         dag=DAG)
 
 

--- a/tests/catalog_preproduction_oai_harvest_dag_test.py
+++ b/tests/catalog_preproduction_oai_harvest_dag_test.py
@@ -2,10 +2,7 @@
 import os
 import unittest
 import airflow
-from unittest.mock import Mock
-from parameterized import parameterized
-from cob_datapipeline.catalog_preproduction_oai_harvest_dag import DAG, choose_indexing_branch
-
+from cob_datapipeline.catalog_preproduction_oai_harvest_dag import DAG
 
 class TestCatalogPreproductionOaiHarvest(unittest.TestCase):
     """Unit Tests for solrcloud catalog preproduction oai harvest dag file."""
@@ -25,22 +22,3 @@ class TestCatalogPreproductionOaiHarvest(unittest.TestCase):
         self.assertEqual(task.env["COMMAND"], "ingest")
         self.assertEqual(task.bash_command, expected_bash_path)
 
-    @parameterized.expand([
-        ({"updated": 834, "deleted": 2}, "updates_and_deletes_branch"),
-        ({"updated": 834, "deleted": 0}, "updates_only_branch"),
-        ({"updated": 0, "deleted": 2}, "deletes_only_branch"),
-        ({"updated": 0, "deleted": 0}, "no_updates_no_deletes_branch"),
-    ])
-    def test_choose_indexing_branch(self, harvest_data, expected_branch):
-        # Mock the TaskInstance (ti) object and its xcom_pull method
-        mock_ti = Mock()
-        mock_ti.xcom_pull.return_value = harvest_data
-
-        # Mock kwargs to pass to the function
-        mock_kwargs = {'ti': mock_ti}
-
-        # Call the function with the mocked kwargs
-        result = choose_indexing_branch(**mock_kwargs)
-
-        # Assert that the function returns the correct branch
-        assert result == expected_branch


### PR DESCRIPTION
* Also moves method for choosing a branch to a shared location so that it can be shared by pre-production and production dag.
* Also updates the branch choosing method to return a list of tasks to run vs just the name of the first task in a branch to run.
* Also updates the trigger rules so that tasks are't blocked by upstream skips.