### PR TITLE
Fix harvest dags not working.

### DIFF
--- a/cob_datapipeline/catalog_production_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_production_oai_harvest_dag.py
@@ -165,6 +165,14 @@ OAI_HARVEST = PythonOperator(
     dag=DAG
 )
 
+LIST_UPDATED_FILES = S3ListOperator(
+        task_id="list_updated_files",
+        bucket=AIRFLOW_DATA_BUCKET,
+        prefix=DAG.dag_id + f"/{ S3_NAME_SPACE }/new-updated",
+        delimiter="/",
+        aws_conn_id=AIRFLOW_S3.conn_id,
+        )
+
 INDEX_UPDATES_OAI_MARC = BashOperator(
     task_id="index_updates_oai_marc",
     bash_command=AIRFLOW_HOME + "/dags/cob_datapipeline/scripts/ingest_marc.sh ",
@@ -172,7 +180,6 @@ INDEX_UPDATES_OAI_MARC = BashOperator(
         "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
         "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
         "BUCKET": AIRFLOW_DATA_BUCKET,
-        "FOLDER": DAG.dag_id + f"/{ S3_NAME_SPACE }/new-updated",
         "GIT_BRANCH": COB_INDEX_VERSION,
         "HOME": AIRFLOW_USER_HOME,
         "LATEST_RELEASE": "false",
@@ -185,6 +192,14 @@ INDEX_UPDATES_OAI_MARC = BashOperator(
     trigger_rule="none_failed_min_one_success",
     dag=DAG
 )
+
+LIST_DELETED_FILES = S3ListOperator(
+        task_id="list_deleted_files",
+        bucket=AIRFLOW_DATA_BUCKET,
+        prefix=DAG.dag_id + f"/{ S3_NAME_SPACE }/deleted",
+        delimiter="/",
+        aws_conn_id=AIRFLOW_S3.conn_id,
+        )
 
 INDEX_DELETES_OAI_MARC = BashOperator(
     task_id="index_deletes_oai_marc",
@@ -271,6 +286,7 @@ CHOOSE_INDEXING_BRANCH.set_upstream(OAI_HARVEST)
 # updates_only
 (CHOOSE_INDEXING_BRANCH
  >> UPDATES_ONLY_BRANCH
+ >> LIST_UPDATED_FILES
  >> INDEX_UPDATES_OAI_MARC
  >> SOLR_COMMIT
  >> GET_NUM_SOLR_DOCS_POST
@@ -281,6 +297,7 @@ CHOOSE_INDEXING_BRANCH.set_upstream(OAI_HARVEST)
 # deletes_only
 (CHOOSE_INDEXING_BRANCH
  >> DELETES_ONLY_BRANCH
+ >> LIST_DELETED_FILES
  >> INDEX_DELETES_OAI_MARC
  >> SOLR_COMMIT
  >> GET_NUM_SOLR_DOCS_POST
@@ -291,7 +308,9 @@ CHOOSE_INDEXING_BRANCH.set_upstream(OAI_HARVEST)
 # updates_and_deletes
 (CHOOSE_INDEXING_BRANCH
  >> UPDATES_AND_DELETES_BRANCH
+ >> LIST_UPDATED_FILES
  >> INDEX_UPDATES_OAI_MARC
+ >> LIST_DELETED_FILES
  >> INDEX_DELETES_OAI_MARC
  >> SOLR_COMMIT
  >> GET_NUM_SOLR_DOCS_POST


### PR DESCRIPTION
We made an update to the marc ingesting script that requires the list of files to be processed be passed in via a DATA environment variable.

This change was required to allow for concurrent indexing.

This commit updates the harvest dags to set DATA env variable as required by the new script.