### PR TITLE
Allow more time for indexing.

### DIFF
--- a/cob_datapipeline/catalog_production_oai_harvest_dag.py
+++ b/cob_datapipeline/catalog_production_oai_harvest_dag.py
@@ -183,7 +183,7 @@ INDEX_UPDATES_OAI_MARC = BashOperator(
         "DATA": '\'{{ ti.xcom_pull(task_ids="list_updated_files") | tojson }}\'',
         },
     trigger_rule="none_failed_min_one_success",
-    execution_timeout=timedelta(hours=24),
+    execution_timeout=timedelta(hours=48),
     dag=DAG
 )
 


### PR DESCRIPTION
Sometimes the harvest includes a lot of the same files that are already in harvest and it take a very long time to individually reject each of those imports.